### PR TITLE
add LICENSE to manifest, to fix broken pypi setup

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include *.rst
 recursive-include paypal/express/templates/paypal *.txt *.html
+include LICENSE


### PR DESCRIPTION
pip install fails with 

IOError: [Errno 2] No such file or directory: 'LICENSE'

Pretty sure adding it to MANIFEST will resolve that.
