### PR TITLE
Ensuring that the SHIPTONAME field is set

### DIFF
--- a/paypal/express/gateway.py
+++ b/paypal/express/gateway.py
@@ -210,6 +210,7 @@ def set_txn(basket, shipping_methods, currency, return_url, cancel_url, update_u
     if user:
         params['EMAIL'] = user.email
     if user_address:
+        params['SHIPTONAME'] = user_address.name()
         params['SHIPTOSTREET'] = user_address.line1
         params['SHIPTOSTREET2'] = user_address.line2
         params['SHIPTOCITY'] = user_address.line4
@@ -224,6 +225,7 @@ def set_txn(basket, shipping_methods, currency, return_url, cancel_url, update_u
         # It's recommend not to set 'confirmed shipping' if supplying the
         # shipping address directly.
         params['REQCONFIRMSHIPPING'] = 0
+        params['SHIPTONAME'] = shipping_address.name()
         params['SHIPTOSTREET'] = shipping_address.line1
         params['SHIPTOSTREET2'] = shipping_address.line2
         params['SHIPTOCITY'] = shipping_address.line4


### PR DESCRIPTION
Currently the SHIPTONAME is not being sent for PayPal Express transactions. This poses a problem for gift purchases where the recipient is not the owner of the PayPal account.
