### PR TITLE
Add support for (adaptive) parallel payments

### DIFF
--- a/paypal/adaptive/gateway.py
+++ b/paypal/adaptive/gateway.py
@@ -51,9 +51,7 @@ def pay(receivers, currency, return_url, cancel_url,
     ]
 
     # Chained payment?
-    is_chained = False
-    if True in [r.is_primary for r in receivers]:
-        is_chained = True
+    is_chained = any([r.is_primary for r in receivers])
 
     total = D('0.00')
     for index, receiver in enumerate(receivers):


### PR DESCRIPTION
By default, only chained payment was taken into account with the is_primary parameter giving the total amount for the order.
