### PR TITLE
Updating the 'url' template tags to use the quoting style for Django 1.5

### DIFF
--- a/paypal/templates/paypal/express/dashboard/transaction_detail.html
+++ b/paypal/templates/paypal/express/dashboard/transaction_detail.html
@@ -9,11 +9,11 @@
 {% block breadcrumbs %}
     <ul class="breadcrumb">
         <li>
-            <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>
+            <a href="{% url 'dashboard:index' %}">{% trans "Dashboard" %}</a>
             <span class="divider">/</span>
         </li>
         <li>
-            <a href="{% url paypal-express-list %}">{% trans "PayPal Express" %}</a>
+            <a href="{% url 'paypal-express-list' %}">{% trans "PayPal Express" %}</a>
             <span class="divider">/</span>
         </li>
         <li class="active">

--- a/paypal/templates/paypal/express/dashboard/transaction_list.html
+++ b/paypal/templates/paypal/express/dashboard/transaction_list.html
@@ -9,11 +9,11 @@
 {% block breadcrumbs %}
     <ul class="breadcrumb">
         <li>
-            <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>
+            <a href="{% url 'dashboard:index' %}">{% trans "Dashboard" %}</a>
             <span class="divider">/</span>
         </li>
         <li>
-            <a href="{% url paypal-express-list %}">{% trans "PayPal Express" %}</a>
+            <a href="{% url 'paypal-express-list' %}">{% trans "PayPal Express" %}</a>
             <span class="divider">/</span>
         </li>
         <li class="active">{% trans "Transactions" %}</li>
@@ -42,7 +42,7 @@
             <tbody>
                 {% for txn in transactions %}
                     <tr>
-                        <td><a href="{% url paypal-express-detail txn.id %}">{{ txn.correlation_id|default:"-" }}</a></td>
+                        <td><a href="{% url 'paypal-express-detail' txn.id %}">{{ txn.correlation_id|default:"-" }}</a></td>
                         <td>{{ txn.method }}</td>
                         <td>{{ txn.ack }}</td>
                         <td>{{ txn.amount|currency|default:"-" }} {{ txt.currency }}</td>

--- a/paypal/templates/paypal/express/preview.html
+++ b/paypal/templates/paypal/express/preview.html
@@ -25,7 +25,7 @@
 
 {% block place_order %}
     <h3>{% trans "Please review the information above, then click 'Place Order'" %}</h3>
-    <form method="post" action="{% url paypal-place-order %}">
+    <form method="post" action="{% url 'paypal-place-order' %}">
         {% csrf_token %}
         <input type="hidden" name="payer_id" value="{{ payer_id }}" />
         <input type="hidden" name="token" value="{{ token }}" />

--- a/paypal/templates/paypal/payflow/transaction_detail.html
+++ b/paypal/templates/paypal/payflow/transaction_detail.html
@@ -9,11 +9,11 @@
 {% block breadcrumbs %}
 <ul class="breadcrumb">
     <li>
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>
+        <a href="{% url 'dashboard:index' %}">{% trans "Dashboard" %}</a>
         <span class="divider">/</span>
     </li>
     <li>
-        <a href="{% url paypal-payflow-list %}">{% trans "PayPal Payflow" %}</a>
+        <a href="{% url 'paypal-payflow-list' %}">{% trans "PayPal Payflow" %}</a>
         <span class="divider">/</span>
     </li>
 	<li class="active"><a href=".">{% trans "Transaction" %} {{ txn.pnref }}</a></li>

--- a/paypal/templates/paypal/payflow/transaction_list.html
+++ b/paypal/templates/paypal/payflow/transaction_list.html
@@ -9,11 +9,11 @@
 {% block breadcrumbs %}
 <ul class="breadcrumb">
     <li>
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>
+        <a href="{% url 'dashboard:index' %}">{% trans "Dashboard" %}</a>
         <span class="divider">/</span>
     </li>
     <li>
-        <a href="{% url paypal-payflow-list %}">{% trans "PayPal Payflow Pro" %}</a>
+        <a href="{% url 'paypal-payflow-list' %}">{% trans "PayPal Payflow Pro" %}</a>
         <span class="divider">/</span>
     </li>
     <li class="active">{% trans "Transactions" %}</li>
@@ -55,7 +55,7 @@
             <td>{{ txn.response_time|floatformat:0 }}</td>
             <td>{{ txn.date_created }}</td>
             <td>
-                <a href="{% url paypal-payflow-detail txn.id %}" class="btn btn-info">{% trans "View" %}</a>
+                <a href="{% url 'paypal-payflow-detail' txn.id %}" class="btn btn-info">{% trans "View" %}</a>
             </td>
         </tr>
         {% endfor %}


### PR DESCRIPTION
This change is backwards compatible. Details can be found in the Django 1.5 release notes:

https://docs.djangoproject.com/en/dev/releases/1.5/
