### PR TITLE
Validate against zero value baskets

### DIFF
--- a/paypal/express/gateway.py
+++ b/paypal/express/gateway.py
@@ -121,6 +121,9 @@ def set_txn(basket, shipping_methods, currency, return_url, cancel_url, update_u
     if currency == 'USD' and amount > 10000:
         raise exceptions.PayPalError('PayPal can only be used for orders up to 10000 USD')
 
+    if amount <= 0:
+        raise exceptions.PayPalError('Zero value basket is not allowed')
+
     # PAYMENTREQUEST_0_AMT should include tax, shipping and handling
     params = {
         'PAYMENTREQUEST_0_AMT': amount,

--- a/tests/unit/express/api_tests.py
+++ b/tests/unit/express/api_tests.py
@@ -96,4 +96,11 @@ class TestOrderTotal(TestCase):
         self.assertEqual(params['PAYMENTREQUEST_0_AMT'],
                          D('10.00') + D('2.50'))
 
+    def test_forbids_zero_value_basket(self):
+        basket = create_mock_basket(D('0.00'))
+        shipping_methods = [FixedPrice(D('2.50'))]
 
+        with patch('paypal.express.gateway._fetch_response') as mock_fetch:
+            with self.assertRaises(exceptions.PayPalError):
+                gateway.set_txn(basket, shipping_methods, 'GBP',
+                                'http://example.com', 'http://example.com')


### PR DESCRIPTION
At the moment, the library allows these but PayPal will reject them and the customer is left with a misleading message about "An error occurred communicating with PayPal".

We should raise an exception if the value is zero.
