### PR TITLE
shipping_address.name is not a method.

### DIFF
--- a/paypal/express/gateway.py
+++ b/paypal/express/gateway.py
@@ -264,7 +264,7 @@ def set_txn(basket, shipping_methods, currency, return_url, cancel_url, update_u
         # It's recommend not to set 'confirmed shipping' if supplying the
         # shipping address directly.
         params['REQCONFIRMSHIPPING'] = 0
-        params['SHIPTONAME'] = shipping_address.name()
+        params['SHIPTONAME'] = shipping_address.name
         params['SHIPTOSTREET'] = shipping_address.line1
         params['SHIPTOSTREET2'] = shipping_address.line2
         params['SHIPTOCITY'] = shipping_address.line4


### PR DESCRIPTION
inspection of the latest oscar reveals that `shipping_address.name` is actually a property.
