### PR TITLE
Fixes self.basket not found in SuccessResponseView in case of paypal payment exceptions

### DIFF
--- a/paypal/express/views.py
+++ b/paypal/express/views.py
@@ -172,7 +172,7 @@ class SuccessResponseView(PaymentDetailsView):
 
         # Lookup the frozen basket that this txn corresponds to
         try:
-            basket = Basket.objects.get(id=kwargs['basket_id'],
+            self.basket = Basket.objects.get(id=kwargs['basket_id'],
                                         status=Basket.FROZEN)
         except Basket.DoesNotExist:
             messages.error(
@@ -181,7 +181,7 @@ class SuccessResponseView(PaymentDetailsView):
                   "PayPal transaction"))
             return HttpResponseRedirect(reverse('basket:summary'))
 
-        return self.submit(basket, order_kwargs=order_kwargs)
+        return self.submit(self.basket, order_kwargs=order_kwargs)
 
     def fetch_paypal_data(self, payer_id, token):
         self.payer_id = payer_id

--- a/tests/unit/express/view_tests.py
+++ b/tests/unit/express/view_tests.py
@@ -147,3 +147,37 @@ class SubmitOrderTests(MockedPayPalTests):
 
     def test_shipping_address_includes_line2(self):
         self.assertEqual('line2', self.order.shipping_address.line2)
+
+
+class SubmitOrderErrorsTests(MockedPayPalTests):
+    fixtures = ['countries.json']
+
+    def perform_action(self):
+        self.add_product_to_basket(price=D('6.99'))
+
+        # Explicitly freeze basket
+        basket = Basket.objects.all()[0]
+        basket.freeze()
+        url = reverse('paypal-place-order', kwargs={'basket_id': basket.id})
+        self.response = self.client.post(
+            url, {'action': 'place_order',
+                  'payer_id': '12345',
+                  'token': 'EC-8P797793UC466090M'})
+
+    def patch_http_post(self, post):
+        get_response = 'TOKEN=EC%2d6WY34243AN3588740&CHECKOUTSTATUS=PaymentActionCompleted&TIMESTAMP=2012%2d04%2d19T10%3a07%3a46Z&CORRELATIONID=7e9c5efbda3c0&ACK=Success&VERSION=88%2e0&BUILD=2808426&EMAIL=david%2e_1332854868_per%40gmail%2ecom&PAYERID=7ZTRBDFYYA47W&PAYERSTATUS=verified&FIRSTNAME=David&LASTNAME=Winterbottom&COUNTRYCODE=GB&SHIPTONAME=David%20Winterbottom&SHIPTOSTREET=1%20Main%20Terrace&SHIPTOSTREET2=line2&SHIPTOCITY=Wolverhampton&SHIPTOSTATE=West%20Midlands&SHIPTOZIP=W12%204LQ&SHIPTOCOUNTRYCODE=GB&SHIPTOCOUNTRYNAME=United%20Kingdom&ADDRESSSTATUS=Confirmed&CURRENCYCODE=GBP&AMT=33%2e98&SHIPPINGAMT=0%2e00&HANDLINGAMT=0%2e00&TAXAMT=0%2e00&INSURANCEAMT=0%2e00&SHIPDISCAMT=0%2e00&PAYMENTREQUEST_0_CURRENCYCODE=GBP&PAYMENTREQUEST_0_AMT=33%2e98&PAYMENTREQUEST_0_SHIPPINGAMT=0%2e00&PAYMENTREQUEST_0_HANDLINGAMT=0%2e00&PAYMENTREQUEST_0_TAXAMT=0%2e00&PAYMENTREQUEST_0_INSURANCEAMT=0%2e00&PAYMENTREQUEST_0_SHIPDISCAMT=0%2e00&PAYMENTREQUEST_0_TRANSACTIONID=51963679RW630412N&PAYMENTREQUEST_0_INSURANCEOPTIONOFFERED=false&PAYMENTREQUEST_0_SHIPTONAME=David%20Winterbottom&PAYMENTREQUEST_0_SHIPTOSTREET=1%20Main%20Terrace&PAYMENTREQUEST_0_SHIPTOSTREET2=line2&PAYMENTREQUEST_0_SHIPTOCITY=Wolverhampton&PAYMENTREQUEST_0_SHIPTOSTATE=West%20Midlands&PAYMENTREQUEST_0_SHIPTOZIP=W12%204LQ&PAYMENTREQUEST_0_SHIPTOCOUNTRYCODE=GB&PAYMENTREQUEST_0_SHIPTOCOUNTRYNAME=United%20Kingdom&PAYMENTREQUESTINFO_0_TRANSACTIONID=51963679RW630412N&PAYMENTREQUESTINFO_0_ERRORCODE=0'
+        error_response = 'Error'
+        def side_effect(url, payload):
+            if 'GetExpressCheckoutDetails' in payload:
+                return self.get_mock_response(get_response)
+            elif 'DoExpressCheckoutPayment' in payload:
+                return self.get_mock_response(error_response)
+        post.side_effect = side_effect
+
+    def test_paypal_error(self):
+        self.assertTrue('error' in self.response.context_data)
+
+        error = self.response.context_data['error']
+        self.assertEqual(error, "A problem occurred while processing payment for this "
+                      "order - no payment has been taken.  Please "
+                      "contact customer services if this problem persists")


### PR DESCRIPTION
This fixes the error _AttributeError: 'SuccessResponseView' object has no attribute 'basket'_ generated by `SuccessResponseView.get_context_data` in case of paypal exceptions during the payment.

**Description**

Take a look at the `SuccessResponseView`
- the `post` method calls `submit` with `basket` as argument
- `submit` calls `handle_payment` and catches different exceptions
- if `handle_payment` raises an Exception (e.g. `PayPalError`), `submit` calls `self.render_to_response(self.get_context_data(error=msg))` rendering the template with an extra variable `error`
- the method `get_context_data` tries to access to `self.basket` which doesn't exist so it raises an `AttributeError`

**Solution**

The solution consists of setting `self.basket` in `post` as it happens in `get` so that `get_context_data` can find it.
