### PR TITLE
Allows application to pass in Express API credentials in order to support multiple paypal express accounts.

### DIFF
--- a/paypal/express/facade.py
+++ b/paypal/express/facade.py
@@ -22,7 +22,7 @@ def _get_payment_action():
 
 
 def get_paypal_url(basket, shipping_methods, user=None, shipping_address=None,
-                   shipping_method=None, host=None, scheme='https'):
+                   shipping_method=None, host=None, scheme='https', **gateway_kwargs):
     """
     Return the URL for PayPal Express transaction.
 
@@ -74,45 +74,46 @@ def get_paypal_url(basket, shipping_methods, user=None, shipping_address=None,
                    shipping_address=shipping_address,
                    user=user,
                    user_address=address,
-                   no_shipping=no_shipping)
+                   no_shipping=no_shipping,
+                   **gateway_kwargs)
 
 
-def fetch_transaction_details(token):
+def fetch_transaction_details(token, **gateway_kwargs):
     """
     Fetch the completed details about the PayPal transaction.
     """
-    return get_txn(token)
+    return get_txn(token, **gateway_kwargs)
 
 
-def confirm_transaction(payer_id, token, amount, currency):
+def confirm_transaction(payer_id, token, amount, currency, **gateway_kwargs):
     """
     Confirm the payment action.
     """
     return do_txn(payer_id, token, amount, currency,
-                  action=_get_payment_action())
+                  action=_get_payment_action(), **gateway_kwargs)
 
 
-def refund_transaction(token, amount, currency, note=None):
+def refund_transaction(token, amount, currency, note=None, **gateway_kwargs):
     txn = Transaction.objects.get(token=token,
                                   method=DO_EXPRESS_CHECKOUT)
     is_partial = amount < txn.amount
-    return refund_txn(txn.value('TRANSACTIONID'), is_partial, amount, currency)
+    return refund_txn(txn.value('TRANSACTIONID'), is_partial, amount, currency, **gateway_kwargs)
 
 
-def capture_authorization(token, note=None):
+def capture_authorization(token, note=None, **gateway_kwargs):
     """
     Capture a previous authorization.
     """
     txn = Transaction.objects.get(token=token,
                                   method=DO_EXPRESS_CHECKOUT)
     return do_capture(txn.value('TRANSACTIONID'),
-                      txn.amount, txn.currency, note=note)
+                      txn.amount, txn.currency, note=note, **gateway_kwargs)
 
 
-def void_authorization(token, note=None):
+def void_authorization(token, note=None, **gateway_kwargs):
     """
     Void a previous authorization.
     """
     txn = Transaction.objects.get(token=token,
                                   method=DO_EXPRESS_CHECKOUT)
-    return do_void(txn.value('TRANSACTIONID'), note=note)
+    return do_void(txn.value('TRANSACTIONID'), note=note, **gateway_kwargs)

--- a/paypal/express/mixins.py
+++ b/paypal/express/mixins.py
@@ -1,0 +1,9 @@
+
+class GatewayViewMixin(object):
+    ''' mixin for views that call gateway functions '''
+    def get_gateway_kwargs(self):
+        '''
+        override this method to pass custom / additional params to
+        the Paypal API.
+        '''
+        return {}


### PR DESCRIPTION
...als rather that override credentials normally defined in settings.  This allows the a single installation to support multiple Paypal Express accounts.

- added gateway_kwargs as parameter to express gateway functions
 - allows views to pass extra params to gateway
 - allows views to override default gateway params (for example, API credentials)
- added GatewayViewMixin that adds method: get_gateway_kwargs to Paypal Express views that call gateway
 - allows applications to subclass Paypal Express views to inject gateway_kwargs