### PR TITLE
Fixing shipping API calls deprecated in oscar 0.6

### DIFF
--- a/paypal/express/gateway.py
+++ b/paypal/express/gateway.py
@@ -291,7 +291,7 @@ def set_txn(basket, shipping_methods, currency, return_url, cancel_url, update_u
     for index, method in enumerate(shipping_methods):
         is_default = index == 0
         params['L_SHIPPINGOPTIONISDEFAULT%d' % index] = 'true' if is_default else 'false'
-        charge = method.basket_charge_incl_tax()
+        charge = method.charge_incl_tax
         if charge > max_charge:
             max_charge = charge
         if is_default:
@@ -302,7 +302,7 @@ def set_txn(basket, shipping_methods, currency, return_url, cancel_url, update_u
 
     # Set shipping charge explicitly if it has been passed
     if shipping_method:
-        max_charge = charge = shipping_method.basket_charge_incl_tax()
+        max_charge = charge = shipping_method.charge_incl_tax
         params['PAYMENTREQUEST_0_SHIPPINGAMT'] = _format_currency(charge)
         params['PAYMENTREQUEST_0_AMT'] += charge
 


### PR DESCRIPTION
The method basket_charge_incl_tax of ShippingMethod has been deprecated in oscar 0.6, and besides that, it causes an exception when called on a WeightBased instance since it does not inherit from Base (which should be used for compatibility purposes)
