### PR TITLE
TypeError: sequence item 0: expected string, int found

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,20 +4,6 @@ from setuptools import setup, find_packages
 from paypal import VERSION
 
 
-MIN_OSCAR_VERSION = (0, 6)
-try:
-    import oscar
-except ImportError:
-    # Oscar not installed
-    pass
-else:
-    # Oscar is installed, assert version is up-to-date
-    if oscar.VERSION < MIN_OSCAR_VERSION:
-        raise ValueError(
-            "Oscar>%s required, current version: %s" % (
-                ".".join(MIN_OSCAR_VERSION), oscar.get_version()))
-
-
 setup(name='django-oscar-paypal',
       version=VERSION,
       url='https://github.com/tangentlabs/django-oscar-paypal',


### PR DESCRIPTION
While trying to update oscar and django-oscar-paypal, I got the following problem.

Analyzing the problem, I found that it's not going to work anyway in this situation:
1. I have django-oscar 0.5.3 and django-oscar-paypal is not installed
2. My requirements.txt have both django-oscar==0.6 and django-oscar-paypal==0.8
3. When trying to install requirements.txt, I got an error because oscar's version is 0.5.3

It works if you install first django-oscar and then django-oscar-paypal.

Or this will work if you don't have django-oscar installed, so the verification is skipped.

``` bash
Downloading/unpacking django-oscar-paypal==0.8 (from -r requirements.txt (line 59))
  Running setup.py egg_info for package django-oscar-paypal
    Traceback (most recent call last):
      File "<string>", line 16, in <module>
      File "setup.py", line 18, in <module>
        ".".join(MIN_OSCAR_VERSION), oscar.get_version()))
    TypeError: sequence item 0: expected string, int found
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 16, in <module>

  File "setup.py", line 18, in <module>

    ".".join(MIN_OSCAR_VERSION), oscar.get_version()))

TypeError: sequence item 0: expected string, int found
```
