### PR TITLE
Error 10002 - Security header is not valid

### DIFF
--- a/paypal/gateway.py
+++ b/paypal/gateway.py
@@ -1,6 +1,7 @@
 import requests
 import time
 import urlparse
+import urllib
 
 from paypal import exceptions
 
@@ -17,9 +18,7 @@ def post(url, params):
         if type(params[k]) == unicode:
             params[k] = params[k].encode('utf-8')
 
-    # PayPal is not expecting urlencoding (e.g. %, +), therefore don't use
-    # urllib.urlencode().
-    payload = '&'.join(['%s=%s' % (key, val) for (key, val) in params.items()])
+    payload = urllib.urlencode(params.items())
 
     start_time = time.time()
     response = requests.post(


### PR DESCRIPTION
After these last updates I started to get an error from PayPal API: "Error 10002 - Security header is not valid". After some reseach, I found the change that is causing the issue:

https://github.com/tangentlabs/django-oscar-paypal/commit/5532ed3c842481e62a33ef4823af1420449b063d#diff-78da9f86d1ad48af1eccc703b5e28c22R22
