### PR TITLE
Express Checkout -  Buyer Pays on PayPal

### DIFF
--- a/docs/express.rst
+++ b/docs/express.rst
@@ -124,7 +124,8 @@ settings.
 * ``PAYPAL_PAGESTYLE`` - name of the Custom Payment Page Style for payment pages
   associated with this button or link
 * ``PAYPAL_PAYFLOW_COLOR`` - background color (6-char hex value) for the payment page
-
+* ``PAYPAL_BUYER_PAYS_ON_PAYPAL`` - If ``True`` you can shorten your checkout flow to
+  let buyers complete their purchases on PayPal. The order confirmation page is skipped (defaults to ``False``)
 
 Some of these options, like the display ones, can be set in your PayPal merchant
 profile.

--- a/paypal/express/facade.py
+++ b/paypal/express/facade.py
@@ -10,8 +10,7 @@ from django.core.exceptions import ImproperlyConfigured
 from paypal.express.models import ExpressTransaction as Transaction
 from paypal.express.gateway import (
     set_txn, get_txn, do_txn, SALE, AUTHORIZATION, ORDER,
-    do_capture, DO_EXPRESS_CHECKOUT, do_void, refund_txn
-)
+    do_capture, DO_EXPRESS_CHECKOUT, do_void, refund_txn, buyer_pays_on_paypal)
 
 
 def _get_payment_action():
@@ -39,8 +38,10 @@ def get_paypal_url(basket, shipping_methods, user=None, shipping_address=None,
     if scheme is None:
         use_https = getattr(settings, 'PAYPAL_CALLBACK_HTTPS', True)
         scheme = 'https' if use_https else 'http'
+
+    response_view_name = 'paypal-handle-order' if buyer_pays_on_paypal else 'paypal-success-response'
     return_url = '%s://%s%s' % (
-        scheme, host, reverse('paypal-success-response', kwargs={
+        scheme, host, reverse(response_view_name, kwargs={
             'basket_id': basket.id}))
     cancel_url = '%s://%s%s' % (
         scheme, host, reverse('paypal-cancel-response', kwargs={

--- a/paypal/express/gateway.py
+++ b/paypal/express/gateway.py
@@ -25,11 +25,14 @@ REFUND_TRANSACTION = 'RefundTransaction'
 
 SALE, AUTHORIZATION, ORDER = 'Sale', 'Authorization', 'Order'
 
+
 # The latest version of the PayPal Express API can be found here:
 # https://developer.paypal.com/docs/classic/release-notes/
 API_VERSION = getattr(settings, 'PAYPAL_API_VERSION', '119')
 
 logger = logging.getLogger('paypal.express')
+
+buyer_pays_on_paypal = lambda: getattr(settings, 'PAYPAL_BUYER_PAYS_ON_PAYPAL', False)
 
 
 def _format_description(description):
@@ -353,8 +356,10 @@ def set_txn(basket, shipping_methods, currency, return_url, cancel_url, update_u
         url = 'https://www.sandbox.paypal.com/webscr'
     else:
         url = 'https://www.paypal.com/webscr'
-    params = (('cmd', '_express-checkout'),
-              ('token', txn.token),)
+    params = [('cmd', '_express-checkout'),
+              ('token', txn.token), ]
+    if buyer_pays_on_paypal():
+        params.append(('useraction', 'commit'))
     return '%s?%s' % (url, urlencode(params))
 
 

--- a/paypal/express/urls.py
+++ b/paypal/express/urls.py
@@ -1,19 +1,19 @@
+from django.conf import settings
 from django.conf.urls import *
 from django.views.decorators.csrf import csrf_exempt
 
 from paypal.express import views
+from paypal.express.gateway import buyer_pays_on_paypal
+
+# we need all urls enabled during tests
+_TEST_ENVIRONMENT = getattr(settings, 'TEST_ENVIRONMENT', False)
 
 
 urlpatterns = patterns('',
     # Views for normal flow that starts on the basket page
     url(r'^redirect/', views.RedirectView.as_view(), name='paypal-redirect'),
-    url(r'^preview/(?P<basket_id>\d+)/$',
-        views.SuccessResponseView.as_view(preview=True),
-        name='paypal-success-response'),
     url(r'^cancel/(?P<basket_id>\d+)/$', views.CancelResponseView.as_view(),
         name='paypal-cancel-response'),
-    url(r'^place-order/(?P<basket_id>\d+)/$', views.SuccessResponseView.as_view(),
-        name='paypal-place-order'),
     # Callback for getting shipping options for a specific basket
     url(r'^shipping-options/(?P<basket_id>\d+)/',
         csrf_exempt(views.ShippingOptionsView.as_view()),
@@ -22,3 +22,22 @@ urlpatterns = patterns('',
     url(r'^payment/', views.RedirectView.as_view(as_payment_method=True),
         name='paypal-direct-payment'),
 )
+
+
+if buyer_pays_on_paypal() or _TEST_ENVIRONMENT:
+    urlpatterns += patterns(
+        '',
+        url(r'^handle-order/(?P<basket_id>\d+)/$',
+            views.SuccessResponseView.as_view(preview=True),
+            name='paypal-handle-order'),
+    )
+
+if not buyer_pays_on_paypal() or _TEST_ENVIRONMENT:
+    urlpatterns += patterns(
+        '',
+        url(r'^place-order/(?P<basket_id>\d+)/$', views.SuccessResponseView.as_view(),
+            name='paypal-place-order'),
+        url(r'^preview/(?P<basket_id>\d+)/$',
+            views.SuccessResponseView.as_view(preview=True),
+            name='paypal-success-response'),
+    )

--- a/runtests.py
+++ b/runtests.py
@@ -12,7 +12,6 @@ if not settings.configured:
         'PAYPAL_VERSION': '119',
         'PAYPAL_PAYFLOW_TEST_MODE': True,
         'PAYPAL_BUYER_PAYS_ON_PAYPAL': False,
-        'TEST_ENVIRONMENT': True
     }
     # To specify integration settings (which include passwords, hence why they
     # are not committed), create an integration.py module.

--- a/runtests.py
+++ b/runtests.py
@@ -9,8 +9,10 @@ if not settings.configured:
     extra_settings = {
         'PAYPAL_EXPRESS_URL': 'https://www.sandbox.paypal.com/webscr',
         'PAYPAL_SANDBOX_MODE': True,
-        'PAYPAL_VERSION': '88.0',
+        'PAYPAL_VERSION': '119',
         'PAYPAL_PAYFLOW_TEST_MODE': True,
+        'PAYPAL_BUYER_PAYS_ON_PAYPAL': False,
+        'TEST_ENVIRONMENT': True
     }
     # To specify integration settings (which include passwords, hence why they
     # are not committed), create an integration.py module.

--- a/tests/unit/express/view_tests.py
+++ b/tests/unit/express/view_tests.py
@@ -3,9 +3,10 @@ import random
 
 from decimal import Decimal as D
 
-from django.test import TestCase
-from django.test.client import Client
 from django.core.urlresolvers import reverse, NoReverseMatch
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.test.client import Client
 from mock import patch, Mock
 
 from oscar.apps.order.models import Order
@@ -136,7 +137,7 @@ class EdgeCaseTests(MockedPayPalTests):
                     )
 
 
-class RedirectToPayPalTests(MockedPayPalTests):
+class RedirectToPayPalBase(MockedPayPalTests):
     response_body = 'TOKEN=EC%2d8P797793UC466090M&TIMESTAMP=2012%2d04%2d16T11%3a50%3a38Z&CORRELATIONID=bdd6641577803&ACK=Success&VERSION=60%2e0&BUILD=2808426'
 
     def perform_action(self):
@@ -144,11 +145,26 @@ class RedirectToPayPalTests(MockedPayPalTests):
         response = self.client.get(reverse('paypal-redirect'))
         self.url = URL.from_string(response['Location'])
 
+
+class RedirectToPayPalTests(RedirectToPayPalBase):
+
     def test_nonempty_basket_redirects_to_paypal(self):
         self.assertEqual('www.sandbox.paypal.com', self.url.host())
 
     def test_query_params_present(self):
         params = ['cmd', 'token']
+        self.assertTrue(self.url.has_query_params(params))
+
+
+@override_settings(PAYPAL_BUYER_PAYS_ON_PAYPAL=True)
+class RedirectWhenBuyerPaysOnPayPalTests(RedirectToPayPalBase):
+
+    def test_nonempty_basket_redirects_to_paypal(self):
+        self.assertEqual('www.sandbox.paypal.com', self.url.host())
+
+    def test_query_params_present(self):
+
+        params = ['cmd', 'token', 'useraction']
         self.assertTrue(self.url.has_query_params(params))
 
 
@@ -196,7 +212,28 @@ class PreviewOrderTests(MockedPayPalTests):
             self.assertTrue(k in self.response.context, "%s not in context" % k)
 
 
-class SubmitOrderTests(MockedPayPalTests):
+class SubmitOrderBase(MockedPayPalTests):
+    """
+    """
+    get_response = ''
+    do_response = ''
+
+    def patch_http_post(self, post):
+        get_response = self.get_response
+        do_response = self.do_response
+
+        def side_effect(url, payload, **kwargs):
+            if 'GetExpressCheckoutDetails' in payload:
+                return self.get_mock_response(get_response)
+            elif 'DoExpressCheckoutPayment' in payload:
+                return self.get_mock_response(do_response)
+        post.side_effect = side_effect
+
+
+class SubmitOrderTests(SubmitOrderBase):
+
+    get_response = 'TOKEN=EC%2d6WY34243AN3588740&CHECKOUTSTATUS=PaymentActionCompleted&TIMESTAMP=2012%2d04%2d19T10%3a07%3a46Z&CORRELATIONID=7e9c5efbda3c0&ACK=Success&VERSION=88%2e0&BUILD=2808426&EMAIL=david%2e_1332854868_per%40gmail%2ecom&PAYERID=7ZTRBDFYYA47W&PAYERSTATUS=verified&FIRSTNAME=David&LASTNAME=Winterbottom&COUNTRYCODE=GB&SHIPTONAME=David%20Winterbottom&SHIPTOSTREET=1%20Main%20Terrace&SHIPTOSTREET2=line2&SHIPTOCITY=Wolverhampton&SHIPTOSTATE=West%20Midlands&SHIPTOZIP=W12%204LQ&SHIPTOCOUNTRYCODE=GB&SHIPTOCOUNTRYNAME=United%20Kingdom&ADDRESSSTATUS=Confirmed&CURRENCYCODE=GBP&AMT=33%2e98&SHIPPINGAMT=0%2e00&HANDLINGAMT=0%2e00&TAXAMT=0%2e00&INSURANCEAMT=0%2e00&SHIPDISCAMT=0%2e00&PAYMENTREQUEST_0_CURRENCYCODE=GBP&PAYMENTREQUEST_0_AMT=33%2e98&PAYMENTREQUEST_0_SHIPPINGAMT=0%2e00&PAYMENTREQUEST_0_HANDLINGAMT=0%2e00&PAYMENTREQUEST_0_TAXAMT=0%2e00&PAYMENTREQUEST_0_INSURANCEAMT=0%2e00&PAYMENTREQUEST_0_SHIPDISCAMT=0%2e00&PAYMENTREQUEST_0_TRANSACTIONID=51963679RW630412N&PAYMENTREQUEST_0_INSURANCEOPTIONOFFERED=false&PAYMENTREQUEST_0_SHIPTONAME=David%20Winterbottom&PAYMENTREQUEST_0_SHIPTOSTREET=1%20Main%20Terrace&PAYMENTREQUEST_0_SHIPTOSTREET2=line2&PAYMENTREQUEST_0_SHIPTOCITY=Wolverhampton&PAYMENTREQUEST_0_SHIPTOSTATE=West%20Midlands&PAYMENTREQUEST_0_SHIPTOZIP=W12%204LQ&PAYMENTREQUEST_0_SHIPTOCOUNTRYCODE=GB&PAYMENTREQUEST_0_SHIPTOCOUNTRYNAME=United%20Kingdom&PAYMENTREQUESTINFO_0_TRANSACTIONID=51963679RW630412N&PAYMENTREQUESTINFO_0_ERRORCODE=0'
+    do_response = 'TOKEN=EC%2d6WY34243AN3588740&SUCCESSPAGEREDIRECTREQUESTED=false&TIMESTAMP=2012%2d04%2d19T10%3a07%3a47Z&CORRELATIONID=3db1d5276ddfd&ACK=Success&VERSION=88%2e0&BUILD=2808426&INSURANCEOPTIONSELECTED=false&SHIPPINGOPTIONISDEFAULT=false&PAYMENTINFO_0_TRANSACTIONID=51963679RW630412N&PAYMENTINFO_0_TRANSACTIONTYPE=expresscheckout&PAYMENTINFO_0_PAYMENTTYPE=instant&PAYMENTINFO_0_ORDERTIME=2012%2d04%2d19T09%3a42%3a50Z&PAYMENTINFO_0_AMT=33%2e98&PAYMENTINFO_0_FEEAMT=1%2e36&PAYMENTINFO_0_TAXAMT=0%2e00&PAYMENTINFO_0_CURRENCYCODE=GBP&PAYMENTINFO_0_PAYMENTSTATUS=Pending&PAYMENTINFO_0_PENDINGREASON=paymentreview&PAYMENTINFO_0_REASONCODE=None&PAYMENTINFO_0_PROTECTIONELIGIBILITY=Ineligible&PAYMENTINFO_0_PROTECTIONELIGIBILITYTYPE=None&PAYMENTINFO_0_SECUREMERCHANTACCOUNTID=YYH7BB4UHPKC4&PAYMENTINFO_0_ERRORCODE=0&PAYMENTINFO_0_ACK=Success'
 
     def perform_action(self):
         self.add_product_to_basket(price=D('6.99'))
@@ -211,17 +248,6 @@ class SubmitOrderTests(MockedPayPalTests):
                   'token': 'EC-8P797793UC466090M'})
         self.order = Order.objects.all()[0]
 
-    def patch_http_post(self, post):
-        get_response = 'TOKEN=EC%2d6WY34243AN3588740&CHECKOUTSTATUS=PaymentActionCompleted&TIMESTAMP=2012%2d04%2d19T10%3a07%3a46Z&CORRELATIONID=7e9c5efbda3c0&ACK=Success&VERSION=88%2e0&BUILD=2808426&EMAIL=david%2e_1332854868_per%40gmail%2ecom&PAYERID=7ZTRBDFYYA47W&PAYERSTATUS=verified&FIRSTNAME=David&LASTNAME=Winterbottom&COUNTRYCODE=GB&SHIPTONAME=David%20Winterbottom&SHIPTOSTREET=1%20Main%20Terrace&SHIPTOSTREET2=line2&SHIPTOCITY=Wolverhampton&SHIPTOSTATE=West%20Midlands&SHIPTOZIP=W12%204LQ&SHIPTOCOUNTRYCODE=GB&SHIPTOCOUNTRYNAME=United%20Kingdom&ADDRESSSTATUS=Confirmed&CURRENCYCODE=GBP&AMT=33%2e98&SHIPPINGAMT=0%2e00&HANDLINGAMT=0%2e00&TAXAMT=0%2e00&INSURANCEAMT=0%2e00&SHIPDISCAMT=0%2e00&PAYMENTREQUEST_0_CURRENCYCODE=GBP&PAYMENTREQUEST_0_AMT=33%2e98&PAYMENTREQUEST_0_SHIPPINGAMT=0%2e00&PAYMENTREQUEST_0_HANDLINGAMT=0%2e00&PAYMENTREQUEST_0_TAXAMT=0%2e00&PAYMENTREQUEST_0_INSURANCEAMT=0%2e00&PAYMENTREQUEST_0_SHIPDISCAMT=0%2e00&PAYMENTREQUEST_0_TRANSACTIONID=51963679RW630412N&PAYMENTREQUEST_0_INSURANCEOPTIONOFFERED=false&PAYMENTREQUEST_0_SHIPTONAME=David%20Winterbottom&PAYMENTREQUEST_0_SHIPTOSTREET=1%20Main%20Terrace&PAYMENTREQUEST_0_SHIPTOSTREET2=line2&PAYMENTREQUEST_0_SHIPTOCITY=Wolverhampton&PAYMENTREQUEST_0_SHIPTOSTATE=West%20Midlands&PAYMENTREQUEST_0_SHIPTOZIP=W12%204LQ&PAYMENTREQUEST_0_SHIPTOCOUNTRYCODE=GB&PAYMENTREQUEST_0_SHIPTOCOUNTRYNAME=United%20Kingdom&PAYMENTREQUESTINFO_0_TRANSACTIONID=51963679RW630412N&PAYMENTREQUESTINFO_0_ERRORCODE=0'
-        do_response = 'TOKEN=EC%2d6WY34243AN3588740&SUCCESSPAGEREDIRECTREQUESTED=false&TIMESTAMP=2012%2d04%2d19T10%3a07%3a47Z&CORRELATIONID=3db1d5276ddfd&ACK=Success&VERSION=88%2e0&BUILD=2808426&INSURANCEOPTIONSELECTED=false&SHIPPINGOPTIONISDEFAULT=false&PAYMENTINFO_0_TRANSACTIONID=51963679RW630412N&PAYMENTINFO_0_TRANSACTIONTYPE=expresscheckout&PAYMENTINFO_0_PAYMENTTYPE=instant&PAYMENTINFO_0_ORDERTIME=2012%2d04%2d19T09%3a42%3a50Z&PAYMENTINFO_0_AMT=33%2e98&PAYMENTINFO_0_FEEAMT=1%2e36&PAYMENTINFO_0_TAXAMT=0%2e00&PAYMENTINFO_0_CURRENCYCODE=GBP&PAYMENTINFO_0_PAYMENTSTATUS=Pending&PAYMENTINFO_0_PENDINGREASON=paymentreview&PAYMENTINFO_0_REASONCODE=None&PAYMENTINFO_0_PROTECTIONELIGIBILITY=Ineligible&PAYMENTINFO_0_PROTECTIONELIGIBILITYTYPE=None&PAYMENTINFO_0_SECUREMERCHANTACCOUNTID=YYH7BB4UHPKC4&PAYMENTINFO_0_ERRORCODE=0&PAYMENTINFO_0_ACK=Success'
-
-        def side_effect(url, payload, **kwargs):
-            if 'GetExpressCheckoutDetails' in payload:
-                return self.get_mock_response(get_response)
-            elif 'DoExpressCheckoutPayment' in payload:
-                return self.get_mock_response(do_response)
-        post.side_effect = side_effect
-
     def test_order_total(self):
         self.assertEqual(D('6.99'), self.order.total_incl_tax)
 
@@ -231,6 +257,38 @@ class SubmitOrderTests(MockedPayPalTests):
 
     def test_shipping_address_includes_line2(self):
         self.assertEqual('line2', self.order.shipping_address.line2)
+
+
+@override_settings(PAYPAL_BUYER_PAYS_ON_PAYPAL=True)
+class BuyerPaysOnPaypalResponseTests(SubmitOrderBase):
+
+    get_response = 'TOKEN=EC%2d7F151994RW7618524&BILLINGAGREEMENTACCEPTEDSTATUS=0&CHECKOUTSTATUS=PaymentActionNotInitiated&TIMESTAMP=2014%2d12%2d14T10%3a49%3a10Z&CORRELATIONID=5ef454cceaf17&ACK=Success&VERSION=119&BUILD=14107150&EMAIL=info%2dbuyer%40test%2ecom&PAYERID=Y8K3PSJYN24D4&PAYERSTATUS=verified&FIRSTNAME=Test&LASTNAME=Buyer&COUNTRYCODE=IT&SHIPTONAME=Test%20Buyer&SHIPTOSTREET=street%20Test%2c%201&SHIPTOSTREET2=line2&SHIPTOCITY=London&SHIPTOSTATE=London&SHIPTOZIP=SW74TU&SHIPTOCOUNTRYCODE=GB&SHIPTOCOUNTRYNAME=United%20Kingdom&ADDRESSSTATUS=Confirmed&CURRENCYCODE=EUR&AMT=23%2e99&ITEMAMT=23%2e99&SHIPPINGAMT=0%2e00&HANDLINGAMT=0%2e00&TAXAMT=0%2e00&INSURANCEAMT=0%2e00&SHIPDISCAMT=0%2e00&L_NAME0=Hacking%20Exposed%20Wireless&L_NUMBER0=9780072262582&L_QTY0=1&L_TAXAMT0=0%2e00&L_AMT0=23%2e99&L_DESC0=This%20is%20an%20invaluable%20resource%20for%20any%20IT%20professional%20who%20works%20with%20%2e%2e%2e&L_ITEMWEIGHTVALUE0=%20%20%200%2e00000&L_ITEMLENGTHVALUE0=%20%20%200%2e00000&L_ITEMWIDTHVALUE0=%20%20%200%2e00000&L_ITEMHEIGHTVALUE0=%20%20%200%2e00000&PAYMENTREQUEST_0_CURRENCYCODE=EUR&PAYMENTREQUEST_0_AMT=23%2e99&PAYMENTREQUEST_0_ITEMAMT=23%2e99&PAYMENTREQUEST_0_SHIPPINGAMT=0%2e00&PAYMENTREQUEST_0_HANDLINGAMT=0%2e00&PAYMENTREQUEST_0_TAXAMT=0%2e00&PAYMENTREQUEST_0_INSURANCEAMT=0%2e00&PAYMENTREQUEST_0_SHIPDISCAMT=0%2e00&PAYMENTREQUEST_0_INSURANCEOPTIONOFFERED=false&PAYMENTREQUEST_0_SHIPTONAME=Test%20Buyer&PAYMENTREQUEST_0_SHIPTOSTREET=street%20Test%2c%201&PAYMENTREQUEST_0_SHIPTOSTREET2=line2&PAYMENTREQUEST_0_SHIPTOCITY=London&PAYMENTREQUEST_0_SHIPTOSTATE=London&PAYMENTREQUEST_0_SHIPTOZIP=SW74TU&PAYMENTREQUEST_0_SHIPTOCOUNTRYCODE=GB&PAYMENTREQUEST_0_SHIPTOCOUNTRYNAME=United%20Kingdom&PAYMENTREQUEST_0_ADDRESSSTATUS=Confirmed&PAYMENTREQUEST_0_ADDRESSNORMALIZATIONSTATUS=None&L_PAYMENTREQUEST_0_NAME0=Hacking%20Exposed%20Wireless&L_PAYMENTREQUEST_0_NUMBER0=9780072262582&L_PAYMENTREQUEST_0_QTY0=1&L_PAYMENTREQUEST_0_TAXAMT0=0%2e00&L_PAYMENTREQUEST_0_AMT0=23%2e99&L_PAYMENTREQUEST_0_DESC0=This%20is%20an%20invaluable%20resource%20for%20any%20IT%20professional%20who%20works%20with%20%2e%2e%2e&L_PAYMENTREQUEST_0_ITEMWEIGHTVALUE0=%20%20%200%2e00000&L_PAYMENTREQUEST_0_ITEMLENGTHVALUE0=%20%20%200%2e00000&L_PAYMENTREQUEST_0_ITEMWIDTHVALUE0=%20%20%200%2e00000&L_PAYMENTREQUEST_0_ITEMHEIGHTVALUE0=%20%20%200%2e00000&PAYMENTREQUESTINFO_0_ERRORCODE=0'
+    do_response = 'TOKEN=EC%2d7F151994RW7618524&SUCCESSPAGEREDIRECTREQUESTED=false&TIMESTAMP=2014%2d12%2d14T10%3a49%3a42Z&CORRELATIONID=30e7eb7f96acc&ACK=Success&VERSION=119&BUILD=14107150&INSURANCEOPTIONSELECTED=false&SHIPPINGOPTIONISDEFAULT=false&PAYMENTINFO_0_TRANSACTIONID=7TR35978HS6402734&PAYMENTINFO_0_TRANSACTIONTYPE=expresscheckout&PAYMENTINFO_0_PAYMENTTYPE=instant&PAYMENTINFO_0_ORDERTIME=2014%2d12%2d14T10%3a49%3a42Z&PAYMENTINFO_0_AMT=23%2e99&PAYMENTINFO_0_TAXAMT=0%2e00&PAYMENTINFO_0_CURRENCYCODE=EUR&PAYMENTINFO_0_PAYMENTSTATUS=Pending&PAYMENTINFO_0_PENDINGREASON=multicurrency&PAYMENTINFO_0_REASONCODE=None&PAYMENTINFO_0_PROTECTIONELIGIBILITY=Eligible&PAYMENTINFO_0_PROTECTIONELIGIBILITYTYPE=ItemNotReceivedEligible%2cUnauthorizedPaymentEligible&PAYMENTINFO_0_SECUREMERCHANTACCOUNTID=N7DUXYBV52FQ4&PAYMENTINFO_0_ERRORCODE=0&PAYMENTINFO_0_ACK=Success'
+
+    def perform_action(self):
+        self.add_product_to_basket(price=D('23.99'))
+        basket = Basket.objects.first()
+        basket.freeze()
+
+        self.url = reverse('paypal-handle-order', kwargs={'basket_id': basket.id})
+        url = URL().path(self.url)\
+                   .query_param('PayerID', 'Y8K3PSJYN24D4')\
+                   .query_param('token', 'EC-7F151994RW7618524')
+        self.response = self.client.get(str(url), follow=True)
+        self.order = Order.objects.first()
+
+    def test_order_total(self):
+        self.assertEqual(D('23.99'), self.order.total_incl_tax)
+
+    def test_order_email_address(self):
+        self.assertEqual('info-buyer@test.com',
+                         self.order.guest_email)
+
+    def test_order_includes_shipping(self):
+        self.assertEqual('line2', self.order.shipping_address.line2)
+
+    def test_post_should_is_a_bad_request(self):
+        self.assertEqual(self.client.post(self.url, {}).status_code, 400)
 
 
 class SubmitOrderErrorsTests(MockedPayPalTests):

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -2,6 +2,7 @@ from django.conf.urls import include, url, patterns
 from django.conf.urls.i18n import i18n_patterns
 
 from oscar.app import application
+from paypal.express.urls import base_patterns, buyer_pays_on_website_patterns, buyer_pays_on_paypal_patterns
 
 urlpatterns = patterns(
     '',
@@ -9,6 +10,8 @@ urlpatterns = patterns(
 )
 urlpatterns += i18n_patterns(
     '',
-    (r'^checkout/paypal/', include('paypal.express.urls')),
+    (r'^checkout/paypal/', include(base_patterns)),
+    (r'^checkout/paypal/option-paypal/', include(buyer_pays_on_paypal_patterns)),
+    (r'^checkout/paypal/option-website/', include(buyer_pays_on_website_patterns)),
     (r'', include(application.urls)),
 )


### PR DESCRIPTION
PayPal gives the possibility to skip the confirm-order page on your website.

My company had a request about this so I had a quick look but then the client was happy with the current implementation.

I'll try to handle this when I have a bit of free time.

In the meantime, if anyone needs this Express Checkout feature this is the place to start.

[documentation here](https://cms.paypal.com/uk/cgi-bin/?cmd=_render-content&content_ID=developer/e_howto_api_ECCustomizing)

> Buyer Pays on PayPal
> With Express Checkout, you can shorten your checkout flow to let buyers complete their purchases on PayPal. Then, you can skip your order confirmation page.
> 
> Generally, buyers select payment methods as the last step before they complete their purchases. If you collect no additional information after buyers return from PayPal, you can skip the confirm-order page on your website. If you collect additional information that does not affect the payment, PayPal recommends that you collect it after buyers complete their purchases.
> 
> The useraction URL parameter in your redirect to PayPal determines whether buyers complete their purchases on PayPal or on your website. If you set useraction to commit, PayPal sets the button text to Pay Now on the PayPal Review your information page. This text lets buyers know that they complete their purchases if they click the button.
> 
> After PayPal redirects buyers to your site, call GetExpressCheckoutDetails and DoExpressCheckoutPayment to have PayPal complete the payment successfully. Call DoExpressCheckoutPayment without waiting for buyer interaction. Use information in the GetExpressCheckoutDetails response to fill out your order confirmation page.
