### PR TITLE
Use the basket's currency

### DIFF
--- a/paypal/express/facade.py
+++ b/paypal/express/facade.py
@@ -33,7 +33,10 @@ def get_paypal_url(basket, shipping_methods, user=None, shipping_address=None,
     given to PayPal directly - this is used within when using PayPal as a
     payment method.
     """
-    currency = getattr(settings, 'PAYPAL_CURRENCY', 'GBP')
+    if basket.currency:
+        currency = basket.currency
+    else:
+        currency = getattr(settings, 'PAYPAL_CURRENCY', 'GBP')
     if host is None:
         host = Site.objects.get_current().domain
     if scheme is None:


### PR DESCRIPTION
Instead of using a fixed currency from a settings attribute or defaulting to GBP, the basket's currency should always take priority in the event a shop handles different regions/currencies.