### PR TITLE
Fix: Paypal payments using not ascii characters are not correctly handled in Python 2.7

### DIFF
--- a/paypal/base.py
+++ b/paypal/base.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 from django.utils.six.moves.urllib.parse import parse_qs
+from django.utils.encoding import force_text, force_str
 from django.utils.translation import ugettext_lazy as _
 
 from django.db import models
@@ -43,8 +44,8 @@ class ResponseModel(models.Model):
 
     @property
     def context(self):
-        return parse_qs(self.raw_response)
+        return parse_qs(force_str(self.raw_response))
 
     def value(self, key, default=None):
         ctx = self.context
-        return ctx[key][0] if key in ctx else default
+        return force_text(ctx[key][0]) if key in ctx else default

--- a/paypal/gateway.py
+++ b/paypal/gateway.py
@@ -3,6 +3,7 @@ import requests
 import time
 
 from django.utils.http import urlencode
+from django.utils.encoding import force_text, force_str
 from django.utils.six.moves.urllib.parse import parse_qs
 
 from paypal import exceptions
@@ -26,8 +27,9 @@ def post(url, params):
 
     # Convert response into a simple key-value format
     pairs = {}
-    for key, values in parse_qs(response.text).items():
-        pairs[key] = values[0]
+    for key, values in parse_qs(force_str(response.text)).items():
+        pairs[force_text(key)] = force_text(values[0])
+
 
     # Add audit information
     pairs['_raw_request'] = payload


### PR DESCRIPTION
To reproduce this you just do a payment with paypal using a not ascii characters.
A second address would be created.

`parse_qs` parses a query string given as a string argument in Python 2.

We should use `force_str` and `force_text`  for handling Python 2 and Python 3 different behaviours.

This regression was introduced in b5eaa0d by me :-(

The tests are using only ascii characters so they are not failing.
I'll update them next week.
