### PR TITLE
Respect shipping method type

### DIFF
--- a/paypal/base.py
+++ b/paypal/base.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from django.utils import six
 from django.utils.six.moves.urllib.parse import parse_qs
 from django.utils.translation import ugettext_lazy as _
 
@@ -47,4 +48,6 @@ class ResponseModel(models.Model):
 
     def value(self, key, default=None):
         ctx = self.context
+        if isinstance(key, six.text_type):
+            key = key.encode('utf8')
         return ctx[key][0] if key in ctx else default

--- a/paypal/express/views.py
+++ b/paypal/express/views.py
@@ -354,10 +354,7 @@ class SuccessResponseView(PaymentDetailsView):
             basket=basket, user=self.request.user,
             shipping_addr=shipping_address, request=self.request)
         for method in methods:
-            method_name = method.name
-            if isinstance(method_name, six.text_type):
-                method_name = method.name.encode('utf8')
-            if method_name == name:
+            if method.name == name:
                 return method
 
     def get_shipping_method(self, basket, shipping_address=None, **kwargs):

--- a/paypal/gateway.py
+++ b/paypal/gateway.py
@@ -3,7 +3,8 @@ import requests
 import time
 
 from django.utils.http import urlencode
-from django.utils.six.moves.urllib.parse import parse_qs
+from django.utils import six
+from django.utils.six.moves.urllib.parse import parse_qsl
 
 from paypal import exceptions
 
@@ -26,12 +27,16 @@ def post(url, params):
 
     # Convert response into a simple key-value format
     pairs = {}
-    for key, values in parse_qs(response.text).items():
-        pairs[key] = values[0]
+    for key, value in parse_qsl(response.content):
+        if isinstance(key, six.binary_type):
+            key = key.decode('utf8')
+        if isinstance(value, six.binary_type):
+            value = value.decode('utf8')
+        pairs[key] = value
 
     # Add audit information
     pairs['_raw_request'] = payload
-    pairs['_raw_response'] = response.text.encode('utf8')
+    pairs['_raw_response'] = response.content
     pairs['_response_time'] = (time.time() - start_time) * 1000.0
 
     return pairs

--- a/paypal/gateway.py
+++ b/paypal/gateway.py
@@ -31,7 +31,7 @@ def post(url, params):
 
     # Add audit information
     pairs['_raw_request'] = payload
-    pairs['_raw_response'] = response.text
+    pairs['_raw_response'] = response.text.encode('utf8')
     pairs['_response_time'] = (time.time() - start_time) * 1000.0
 
     return pairs

--- a/runtests.py
+++ b/runtests.py
@@ -53,7 +53,9 @@ if not settings.configured:
             'django.contrib.staticfiles',
             'paypal',
             'compressor',
-        ] + get_core_apps(),
+        ] + get_core_apps([
+            'tests.shipping',
+        ]),
         MIDDLEWARE_CLASSES=(
             'django.middleware.common.CommonMiddleware',
             'django.contrib.sessions.middleware.SessionMiddleware',

--- a/tests/shipping/methods.py
+++ b/tests/shipping/methods.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from decimal import Decimal as D
+
+from oscar.apps.shipping.methods import Free
+
+
+class Oscar07Mixin(object):
+    """
+    for Oscar 0.7 compatibility
+    (different shipping method api)
+    """
+    def __call__(self):
+        return self
+
+    def set_basket(self, basket):
+        pass
+
+
+class SecondClassRecorded(Oscar07Mixin, Free):
+    code = 'uk_rm_2ndrecorded'
+    name = 'Royal Mail Signed For™ 2nd Class'
+
+    charge_excl_tax = D('0.00')
+    charge_incl_tax = D('0.00')

--- a/tests/shipping/models.py
+++ b/tests/shipping/models.py
@@ -1,0 +1,1 @@
+from oscar.apps.shipping.models import *  # noqa

--- a/tests/shipping/repository.py
+++ b/tests/shipping/repository.py
@@ -1,0 +1,9 @@
+from oscar.apps.shipping.repository import Repository as BaseRepository
+
+from . import methods as shipping_methods
+
+
+class Repository(BaseRepository):
+    methods = (
+        shipping_methods.SecondClassRecorded(),
+    )

--- a/tests/unit/express/api_tests.py
+++ b/tests/unit/express/api_tests.py
@@ -32,7 +32,7 @@ class MockedResponseTestCase(TestCase):
 
     def create_mock_response(self, body, status_code=200):
         response = Mock()
-        response.text = body
+        response.content = body
         response.status_code = status_code
         return response
 

--- a/tests/unit/express/facade_tests.py
+++ b/tests/unit/express/facade_tests.py
@@ -17,7 +17,7 @@ class MockedResponseTests(TestCase):
 
     def setUp(self):
         response = Mock()
-        response.text = self.response_body
+        response.content = self.response_body
         response.status_code = 200
         with patch('requests.post') as post:
             post.return_value = response

--- a/tests/unit/express/view_tests.py
+++ b/tests/unit/express/view_tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import random
 
@@ -5,6 +6,7 @@ from decimal import Decimal as D
 
 from django.test import TestCase
 from django.test.client import Client
+from django.utils.encoding import force_text
 from django.core.urlresolvers import reverse, NoReverseMatch
 from mock import patch, Mock
 
@@ -75,7 +77,7 @@ class MockedPayPalTests(TestCase):
 
     def get_mock_response(self, content=None):
         response = Mock()
-        response.text = self.response_body if content is None else content
+        response.content = self.response_body if content is None else content
         response.status_code = 200
         return response
 
@@ -171,7 +173,7 @@ class FailedTxnTests(MockedPayPalTests):
 
 
 class PreviewOrderTests(MockedPayPalTests):
-    response_body = 'TOKEN=EC%2d6WY34243AN3588740&CHECKOUTSTATUS=PaymentActionCompleted&TIMESTAMP=2012%2d04%2d19T10%3a07%3a46Z&CORRELATIONID=7e9c5efbda3c0&ACK=Success&VERSION=88%2e0&BUILD=2808426&EMAIL=david%2e_1332854868_per%40gmail%2ecom&PAYERID=7ZTRBDFYYA47W&PAYERSTATUS=verified&FIRSTNAME=David&LASTNAME=Winterbottom&COUNTRYCODE=GB&SHIPTONAME=David%20Winterbottom&SHIPTOSTREET=1%20Main%20Terrace&SHIPTOCITY=Wolverhampton&SHIPTOSTATE=West%20Midlands&SHIPTOZIP=W12%204LQ&SHIPTOCOUNTRYCODE=GB&SHIPTOCOUNTRYNAME=United%20Kingdom&ADDRESSSTATUS=Confirmed&CURRENCYCODE=GBP&AMT=33%2e98&SHIPPINGAMT=0%2e00&HANDLINGAMT=0%2e00&TAXAMT=0%2e00&INSURANCEAMT=0%2e00&SHIPDISCAMT=0%2e00&PAYMENTREQUEST_0_CURRENCYCODE=GBP&PAYMENTREQUEST_0_AMT=33%2e98&PAYMENTREQUEST_0_SHIPPINGAMT=0%2e00&PAYMENTREQUEST_0_HANDLINGAMT=0%2e00&PAYMENTREQUEST_0_TAXAMT=0%2e00&PAYMENTREQUEST_0_INSURANCEAMT=0%2e00&PAYMENTREQUEST_0_SHIPDISCAMT=0%2e00&PAYMENTREQUEST_0_TRANSACTIONID=51963679RW630412N&PAYMENTREQUEST_0_INSURANCEOPTIONOFFERED=false&PAYMENTREQUEST_0_SHIPTONAME=David%20Winterbottom&PAYMENTREQUEST_0_SHIPTOSTREET=1%20Main%20Terrace&PAYMENTREQUEST_0_SHIPTOCITY=Wolverhampton&PAYMENTREQUEST_0_SHIPTOSTATE=West%20Midlands&PAYMENTREQUEST_0_SHIPTOZIP=W12%204LQ&PAYMENTREQUEST_0_SHIPTOCOUNTRYCODE=GB&PAYMENTREQUEST_0_SHIPTOCOUNTRYNAME=United%20Kingdom&PAYMENTREQUESTINFO_0_TRANSACTIONID=51963679RW630412N&PAYMENTREQUESTINFO_0_ERRORCODE=0'
+    response_body = 'TOKEN=EC%2d6WY34243AN3588740&CHECKOUTSTATUS=PaymentActionCompleted&TIMESTAMP=2012%2d04%2d19T10%3a07%3a46Z&CORRELATIONID=7e9c5efbda3c0&ACK=Success&VERSION=88%2e0&BUILD=2808426&EMAIL=david%2e_1332854868_per%40gmail%2ecom&PAYERID=7ZTRBDFYYA47W&PAYERSTATUS=verified&FIRSTNAME=David&LASTNAME=Winterbottom&COUNTRYCODE=GB&SHIPTONAME=David%20Winterbottom&SHIPTOSTREET=1%20Main%20Terrace&SHIPTOCITY=Wolverhampton&SHIPTOSTATE=West%20Midlands&SHIPTOZIP=W12%204LQ&SHIPTOCOUNTRYCODE=GB&SHIPTOCOUNTRYNAME=United%20Kingdom&ADDRESSSTATUS=Confirmed&CURRENCYCODE=GBP&AMT=33%2e98&SHIPPINGAMT=0%2e00&HANDLINGAMT=0%2e00&TAXAMT=0%2e00&INSURANCEAMT=0%2e00&SHIPDISCAMT=0%2e00&PAYMENTREQUEST_0_CURRENCYCODE=GBP&PAYMENTREQUEST_0_AMT=33%2e98&PAYMENTREQUEST_0_SHIPPINGAMT=0%2e00&PAYMENTREQUEST_0_HANDLINGAMT=0%2e00&PAYMENTREQUEST_0_TAXAMT=0%2e00&PAYMENTREQUEST_0_INSURANCEAMT=0%2e00&PAYMENTREQUEST_0_SHIPDISCAMT=0%2e00&PAYMENTREQUEST_0_TRANSACTIONID=51963679RW630412N&PAYMENTREQUEST_0_INSURANCEOPTIONOFFERED=false&PAYMENTREQUEST_0_SHIPTONAME=David%20Winterbottom&PAYMENTREQUEST_0_SHIPTOSTREET=1%20Main%20Terrace&PAYMENTREQUEST_0_SHIPTOCITY=Wolverhampton&PAYMENTREQUEST_0_SHIPTOSTATE=West%20Midlands&PAYMENTREQUEST_0_SHIPTOZIP=W12%204LQ&PAYMENTREQUEST_0_SHIPTOCOUNTRYCODE=GB&PAYMENTREQUEST_0_SHIPTOCOUNTRYNAME=United%20Kingdom&PAYMENTREQUESTINFO_0_TRANSACTIONID=51963679RW630412N&PAYMENTREQUESTINFO_0_ERRORCODE=0&SHIPPINGOPTIONNAME=Royal%20Mail%20Signed%20For%e2%84%a2%202nd%20Class'
 
     def perform_action(self):
         self.add_product_to_basket(price=D('6.99'))
@@ -187,6 +189,10 @@ class PreviewOrderTests(MockedPayPalTests):
 
     def test_context(self):
         self.assertEqual(D('33.98'), self.response.context['paypal_amount'])
+        self.assertEqual('Royal Mail Signed For™ 2nd Class',
+                         force_text(self.response.context['shipping_method'].name))
+        self.assertEqual('uk_rm_2ndrecorded',
+                         force_text(self.response.context['shipping_method'].code))
 
     def test_keys_in_context(self):
         keys = ('shipping_address', 'shipping_method',

--- a/tests/unit/gateway_tests.py
+++ b/tests/unit/gateway_tests.py
@@ -14,7 +14,7 @@ class TestErrorResponse(TestCase):
         with mock.patch('requests.post') as mock_post:
             response = mock.Mock()
             response.status_code = 200
-            response.text = ERROR_RESPONSE
+            response.content = ERROR_RESPONSE
             mock_post.return_value = response
             self.pairs = post('http://example.com', {})
 


### PR DESCRIPTION
I propose this fix for issue #106 ...basically, try to match shipping method returned from PayPal _by name_ with a method defined in shipping `Repository`, in order to use the actual shipping method class and save order with correct `code`.

This PR also fixes a related problem I encountered when trying to match shipping method by name... my name had a ™ char in it. Since the response body is urlencoded the usual unicode handling doesn't work quite right... currently we have a double-encoded unicode type of bug so the incorrectly decoded string returned from PayPal couldn't be matched in the Repository.

We need to instead treat the response body as ascii bytes, give that to `parse_qs` to make a dict then decode the keys and values of the dict as utf8.

Supporting both Py 2 & 3 made the code a bit ugly but this was the minimum change I could find to make the new test pass.