### PR TITLE
`PNREF` Should Be Unique, Not `PPREF`. 

### DIFF
--- a/paypal/payflow/models.py
+++ b/paypal/payflow/models.py
@@ -23,9 +23,9 @@ class PayflowTransaction(base.ResponseModel):
 
     # Response params
     pnref = models.CharField(_("Payflow transaction ID"), max_length=32,
-                             null=True)
-    ppref = models.CharField(_("Payment transaction ID"), max_length=32,
                              unique=True, null=True)
+    ppref = models.CharField(_("Payment transaction ID"), max_length=32,
+                             null=True)
     result = models.CharField(max_length=32, null=True, blank=True)
     respmsg = models.CharField(_("Response message"), max_length=512)
     authcode = models.CharField(_("Auth code"), max_length=32, null=True,


### PR DESCRIPTION
According to latest version of api results it appears that `ppref` is not a unique value. When present it will be a reference to the original PayPal Transaction Id, not the Payflow Gateway Transaction. I contacted their customer support regarding this and they confirmed that. See details below. 

I also included an optional configuration to include other gatway name value paris, like shipping options and such. 

```
Question: When I try to void a transaction through the API it is returning a duplicate PPREF value. Is that supposed to happen? See request and response details below for Authorization and Void transactions. 

paypal.payflow:INFO [gateway.py:188] Performing Authorize transaction (trxtype=A)
paypal.payflow:DEBUG [gateway.py:193] Raw request: VENDOR=xxxx&TRXTYPE=A&ZIP=84770&LASTNAME=Last&COMMENT1=157693&EXPDATE=0320&COMMENT2=&CURRENCY=USD&STATE=&STREET=123+Test+St&USER=XXXX&CVV2=435&TENDER=C&ACCT=4111111111111111&EMAIL=demo%40demo.com&CITY=St+George&FIRSTNAME=Tester&PHONENUM=&PWD=XXXX&BILLTOCOUNTRY=US&PARTNER=PayPal&AMT=33.00
paypal.payflow:DEBUG [gateway.py:194] Raw response: RESULT=0&PNREF=B70P8AC905D5&RESPMSG=Approved&AUTHCODE=111111&AVSADDR=Y&AVSZIP=Y&CVV2MATCH=Y&PPREF=0WS4398121018753N&CORRELATIONID=5fc4393f526e9&IAVS=N

paypal.payflow:INFO [gateway.py:188] Performing Void transaction (trxtype=V)
paypal.payflow:DEBUG [gateway.py:193] Raw request: PWD=XXXX&VENDOR=xxxx&USER=XXXX&PARTNER=PayPal&ORIGID=B70P8AC905D5&COMMENT1=157693&TRXTYPE=V
paypal.payflow:DEBUG [gateway.py:194] Raw response: RESULT=0&PNREF=B10P8C67E5C1&RESPMSG=Approved&PPREF=0WS4398121018753N&CORRELATIONID=e6cd0478b6736
```

```
Response:
Further looking into the question and concerns that you are having, it looks like it is intended functionality. Payflow Void call is very much similar to the PayPal classic API DoVoid API Operation. Whenever you make a DoVoid API call, you are supposed to pass an AUTHORIZATIONID in the API request(which is the original authorization ID) specifying the authorization to void. In the DoVoid Response Message, an AUTHORIZATIONID will be returned, which is the same authorization identification number you specified in the request. So, basically, the same ID that you pass in the request is returned back in the response as well. 

In a similar fashion, when you make an actual Payflow Authorization call, two different transaction ID's will be returned in the response. While one is referred to PNREF, the other one is referred to PPREF.

PNREF is the Gateway transaction ID, a unique number that identifies the transaction.
PPREF is the PayPal transaction ID of the payment; returned by the PayPal processor

In your example, they are PNREF=B70P8AC905D5 and PPREF=0WS4398121018753N

So, when you send a Payflow Void call to void the actual authorization B70P8AC905D5, gateway is again returning back two ID's in the response. While the gateway is returning a different PNREF(B10P8C67E5C1) in the response, it is returning the same/original PayPal authorization ID(0WS4398121018753N) and that is an intended functionality.
```
