### PR TITLE
Payflow Remove Urlencoding

### DIFF
--- a/paypal/gateway.py
+++ b/paypal/gateway.py
@@ -8,7 +8,7 @@ from django.utils.six.moves.urllib.parse import parse_qs
 from paypal import exceptions
 
 
-def post(url, params):
+def post(url, params, encode=True):
     """
     Make a POST request to the URL using the key-value pairs.  Return
     a set of key-value pairs.
@@ -16,7 +16,11 @@ def post(url, params):
     :url: URL to post to
     :params: Dict of parameters to include in post payload
     """
-    payload = urlencode(params)
+    if encode:
+        payload = urlencode(params)
+    else:
+        payload = params
+
     start_time = time.time()
     response = requests.post(
         url, payload,

--- a/paypal/payflow/gateway.py
+++ b/paypal/payflow/gateway.py
@@ -198,7 +198,11 @@ def _transaction(extra_params):
 
     logger.info("Performing %s transaction (trxtype=%s)",
                 codes.trxtype_map[trxtype], trxtype)
-    pairs = gateway.post(url, params)
+    pairs = gateway.post(
+        url,
+        '&'.join(['{}={}'.format(n,v) for n,v in params.items()]), 
+        encode=False
+    )
 
     # Beware - this log information will contain the Payflow credentials
     # only use it in development, not production.

--- a/paypal/payflow/gateway.py
+++ b/paypal/payflow/gateway.py
@@ -65,6 +65,18 @@ def _submit_payment_details(trxtype, order_number, card_number, cvv, expiry_date
         'EMAIL': kwargs.get('user_email', ''),
         'PHONENUM': kwargs.get('billing_phone_number', ''),
     }
+
+    # Allow inclusion of optional parameters in transactions such as:
+    # dict(shipto_first_name='SHIPTOFIRSTNAME', ...)
+    #   OR
+    # dict(bncode='BUTTONSOURCE', ...)
+    OPTIONAL_PARAMS = getattr(settings, 'PAYPAL_PAYFLOW_OPTIONAL_PARAMS', dict())
+    if isinstance(OPTIONAL_PARAMS, dict):
+        # add optional parameters here
+        for key, name in OPTIONAL_PARAMS.items():
+            value = kwargs.get(key)
+            if value:
+                params.update({'{}'.format(name): value})
     return _transaction(params)
 
 

--- a/paypal/payflow/models.py
+++ b/paypal/payflow/models.py
@@ -23,9 +23,9 @@ class PayflowTransaction(base.ResponseModel):
 
     # Response params
     pnref = models.CharField(_("Payflow transaction ID"), max_length=32,
-                             null=True)
-    ppref = models.CharField(_("Payment transaction ID"), max_length=32,
                              unique=True, null=True)
+    ppref = models.CharField(_("Payment transaction ID"), max_length=32,
+                             null=True)
     result = models.CharField(max_length=32, null=True, blank=True)
     respmsg = models.CharField(_("Response message"), max_length=512)
     authcode = models.CharField(_("Auth code"), max_length=32, null=True,


### PR DESCRIPTION
Per Payflow Gateway documentation specifically indicates NVP's should not be `urlencoded`. 

[Do Not URL Encode Name-Value Parameter Data](https://developer.paypal.com/docs/classic/payflow/integration-guide/#do-not-url-encode-name-value-parameter-data)
_Do not URL encode your NVP data because it can cause problems with authentication and reporting._ 
