### PR TITLE
Grab basket object from build_submission(), not from request

### DIFF
--- a/paypal/express/views.py
+++ b/paypal/express/views.py
@@ -61,7 +61,7 @@ class RedirectView(CheckoutSessionMixin, RedirectView):
 
     def get_redirect_url(self, **kwargs):
         try:
-            basket = self.request.basket
+            basket = self.build_submission()['basket']
             url = self._get_redirect_url(basket, **kwargs)
         except PayPalError as ppe:
             messages.error(


### PR DESCRIPTION
When the RedirectView is used in combination with another
CheckoutSessionMixin defined for a DeferredTax taxation strategy, then
submission's basket object has critical tax information, whereas
request.basket does not. Change RedirectView's basket reference to
point to build_submission()['basket'].

Fixes django-oscar/django-oscar-paypal#98, reported by Nigel Fletton.