### PR TITLE
Specify compressor version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
+# django-compressor 2.0 dropped support for Django 1.7.  Since Django
+# 1.7 is still considered supported by django-oscar-paypal, ensure
+# using django-compressor 1.6 (which still supported Django 1.7).
+django-compressor==1.6
+
 # Testing
 mock==1.0.1
 coverage==3.7.1


### PR DESCRIPTION
With its 2.0 release, django-compressor 2.0 dropped support for Django
1.7. Since Django 1.7 is still considered supported by
django-oscar-paypal, ensure using django-compressor 1.6 (which still
supported Django 1.7).

See also:

https://github.com/django-compressor/django-compressor/commit/e27fce758f0b11ba5fb5562c90832e02ac0006cf