### PR TITLE
Force django-compressor version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,4 +8,5 @@ deps =
     django17: Django==1.7.10
     django18: Django==1.8.5
     oscar10: django-oscar==1.0.2
+    django17-oscar10: django-compressor==1.6
     oscar11: django-oscar==1.1.1


### PR DESCRIPTION
This commit is inspired by work in #122. We don't specify an upper bound for
django-compressor in Oscar 1.0. compressor 2.0 was released, which dropped
support for Django 1.7, which means our tests fail.

As this is a bit of an artefact, I prefer to specify the compressor version in
the testing requirements specific to the affected combination of Django and
Oscar versions instead of globally as done in #122.

This commit forces the version of compressor. That's good enough, given that
we're about to drop Django 1.7 support as well with Oscar 1.2.

Thanks go to @fghaas for the excellent analysis.