### PR TITLE
Bugfix UnicodeEncodeError

### DIFF
--- a/paypal/gateway.py
+++ b/paypal/gateway.py
@@ -27,7 +27,7 @@ def post(url, params):
 
     # Convert response into a simple key-value format
     pairs = {}
-    for key, value in parse_qsl(response.content):
+    for key, value in parse_qsl(response.text):
         if isinstance(key, six.binary_type):
             key = key.decode('utf8')
         if isinstance(value, six.binary_type):
@@ -36,7 +36,7 @@ def post(url, params):
 
     # Add audit information
     pairs['_raw_request'] = payload
-    pairs['_raw_response'] = response.content
+    pairs['_raw_response'] = response.text
     pairs['_response_time'] = (time.time() - start_time) * 1000.0
 
     return pairs


### PR DESCRIPTION
When Unicode data is received,
UnicodeEncodeError Exception is occurred.

Requests Response Content
>>> import requests
>>> r = requests.get('https://api.github.com/events')
r.text is of type string.(http://docs.python-requests.org/en/latest/user/quickstart/#response-content)
r.content is of type binary.(http://docs.python-requests.org/en/latest/user/quickstart/#binary-response-content)

Fixes django-oscar/django-oscar-paypal#120, reported by ctchanac.