### PR TITLE
Preserve phone numbers across PayPal Express transactions

### DIFF
--- a/paypal/express/gateway.py
+++ b/paypal/express/gateway.py
@@ -275,6 +275,7 @@ def set_txn(basket, shipping_methods, currency, return_url, cancel_url, update_u
         params['SHIPTOSTATE'] = user_address.state
         params['SHIPTOZIP'] = user_address.postcode
         params['SHIPTOCOUNTRYCODE'] = user_address.country.iso_3166_1_a2
+        params['SHIPTOPHONENUM'] = user_address.phone_number
 
     # Shipping details (if already set) - we override the SHIPTO* fields and
     # set a flag to indicate that these can't be altered on the PayPal side.
@@ -290,6 +291,7 @@ def set_txn(basket, shipping_methods, currency, return_url, cancel_url, update_u
         params['SHIPTOSTATE'] = shipping_address.state
         params['SHIPTOZIP'] = shipping_address.postcode
         params['SHIPTOCOUNTRYCODE'] = shipping_address.country.iso_3166_1_a2
+        params['SHIPTOPHONENUM'] = shipping_address.phone_number
 
         # For US addresses, we need to try and convert the state into 2 letter
         # code - otherwise we can get a 10736 error as the shipping address and

--- a/paypal/express/views.py
+++ b/paypal/express/views.py
@@ -347,7 +347,8 @@ class SuccessResponseView(PaymentDetailsView):
             line4=self.txn.value('PAYMENTREQUEST_0_SHIPTOCITY', default=""),
             state=self.txn.value('PAYMENTREQUEST_0_SHIPTOSTATE', default=""),
             postcode=self.txn.value('PAYMENTREQUEST_0_SHIPTOZIP', default=""),
-            country=Country.objects.get(iso_3166_1_a2=self.txn.value('PAYMENTREQUEST_0_SHIPTOCOUNTRYCODE'))
+            country=Country.objects.get(iso_3166_1_a2=self.txn.value('PAYMENTREQUEST_0_SHIPTOCOUNTRYCODE')),
+            phone_number=self.txn.value('PAYMENTREQUEST_0_SHIPTOPHONENUM', default=""),
         )
 
     def _get_shipping_method_by_name(self, name, basket, shipping_address=None):


### PR DESCRIPTION
When stores collect customers' phone numbers, they may do so for good reason and may want them preserved on order confirmations and receipts. The PayPal Express views previously would not forward this information to PayPal (despite an optional field, `PAYMENTREQUEST_n_SHIPTOPHONENUM`, being available for this purpose in the NVP API). Since in the confirmation view the shipping address is constructed from the PayPal response, not the previously entered user data, this would mean that the phone number would silently get lost in the transaction.

Fix PayPal Express so that user address / shipping address fields are correctly translated into the `PAYMENTREQUEST_n_SHIPTOPHONENUM` param on send, and then re-initialize the shipping address using this information on receive.

Relevant PayPal API reference: https://developer.paypal.com/docs/classic/api/merchant/SetExpressCheckout_API_Operation_NVP/
