### PR TITLE
[IMP] Allows to identify if a product is `Digital` or `Physical`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,3 +27,4 @@ joaoxsouls
 Filip Jukic
 armutcu
 Adam Charnock
+David Díaz

--- a/paypal/express/gateway.py
+++ b/paypal/express/gateway.py
@@ -206,6 +206,8 @@ def set_txn(basket, shipping_methods, currency, return_url, cancel_url, update_u
         params['L_PAYMENTREQUEST_0_AMT%d' % index] = _format_currency(
             line.unit_price_incl_tax)
         params['L_PAYMENTREQUEST_0_QTY%d' % index] = line.quantity
+        params['L_PAYMENTREQUEST_0_ITEMCATEGORY%d' % index] = (
+            'Physical' if product.is_shipping_required() else 'Digital')
 
     # If the order has discounts associated with it, the way PayPal suggests
     # using the API is to add a separate item for the discount with the value

--- a/paypal/express/gateway.py
+++ b/paypal/express/gateway.py
@@ -207,7 +207,7 @@ def set_txn(basket, shipping_methods, currency, return_url, cancel_url, update_u
             line.unit_price_incl_tax)
         params['L_PAYMENTREQUEST_0_QTY%d' % index] = line.quantity
         params['L_PAYMENTREQUEST_0_ITEMCATEGORY%d' % index] = (
-            'Physical' if product.is_shipping_required() else 'Digital')
+            'Physical' if product.is_shipping_required else 'Digital')
 
     # If the order has discounts associated with it, the way PayPal suggests
     # using the API is to add a separate item for the discount with the value


### PR DESCRIPTION
This improvement allows to identify if a product is `Digital` or `Physical` depending on the value of `product.is_shipping_required` by using the express checkout method.

Is necessary to set this property to each product to avoid PayPal whithholds founds during a period of time.
