### PR TITLE
take shipping costs into consideration when evaluating amount in gateway

### DIFF
--- a/paypal/express/gateway.py
+++ b/paypal/express/gateway.py
@@ -171,12 +171,16 @@ def set_txn(basket, shipping_methods, currency, return_url, cancel_url, update_u
     # fiddly to work with.  Lazy solution - only check when dollars are used as
     # the PayPal currency.
     amount = basket.total_incl_tax
+
+    if shipping_method:
+        amount_shipping = shipping_method.calculate(basket).incl_tax
+
     if currency == 'USD' and amount > 10000:
         msg = 'PayPal can only be used for orders up to 10000 USD'
         logger.error(msg)
         raise express_exceptions.InvalidBasket(_(msg))
 
-    if amount <= 0:
+    if amount <= 0 and amount_shipping <= 0:
         msg = 'The basket total is zero so no payment is required'
         logger.error(msg)
         raise express_exceptions.InvalidBasket(_(msg))


### PR DESCRIPTION
We have a client who has free products in his shop. However, shipping can still apply. The client wants the customers to be able to pay for the shipping costs with paypal. 

These changes allow for exactly that.