### PR TITLE
doc(migratesystem): `syncdb` change to `migrate`

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,9 +35,10 @@ By default, this won't install Oscar as well. To install Oscar, run::
 
     pip install "django-oscar-paypal[oscar]"
 
-Finally, add ``paypal`` to your ``INSTALLED_APPS``, and run::
+Finally, add ``paypal`` to your ``INSTALLED_APPS``, and run migration::
 
-    python manage.py syncdb
+    python manage.py makemigrations
+    python manage.py migrate
 
 Table of contents
 -----------------


### PR DESCRIPTION
**Why ?**

Now in django 1.9 syncdb has been deprecated and oscar-paypal has migrate to django 2.

**How ?**

Change to `makemigrations` and `migrate`.