### PR TITLE
Buyer pays on paypal

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,3 +28,4 @@ Filip Jukic
 armutcu
 Adam Charnock
 David Díaz
+Wout De Puysseleir

--- a/docs/express.rst
+++ b/docs/express.rst
@@ -124,6 +124,8 @@ settings.
 * ``PAYPAL_PAGESTYLE`` - name of the Custom Payment Page Style for payment pages
   associated with this button or link
 * ``PAYPAL_PAYFLOW_COLOR`` - background color (6-char hex value) for the payment page
+* ``PAYPAL_BUYER_PAYS_ON_PAYPAL`` - If ``True`` you can shorten your checkout flow to
+  let buyers complete their purchases on PayPal. The order confirmation page is skipped (defaults to ``False``)
 
 
 Some of these options, like the display ones, can be set in your PayPal merchant

--- a/paypal/express/facade.py
+++ b/paypal/express/facade.py
@@ -7,7 +7,8 @@ from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse
 
 from paypal.express.gateway import (
-    AUTHORIZATION, DO_EXPRESS_CHECKOUT, ORDER, SALE, do_capture, do_txn, do_void, get_txn, refund_txn, set_txn)
+    AUTHORIZATION, DO_EXPRESS_CHECKOUT, ORDER, SALE, buyer_pays_on_paypal, do_capture, do_txn, do_void,
+    get_txn, refund_txn, set_txn)
 from paypal.express.models import ExpressTransaction as Transaction
 
 
@@ -39,21 +40,16 @@ def get_paypal_url(basket, shipping_methods, user=None, shipping_address=None,
     if scheme is None:
         use_https = getattr(settings, 'PAYPAL_CALLBACK_HTTPS', True)
         scheme = 'https' if use_https else 'http'
-    return_url = '%s://%s%s' % (
-        scheme, host, reverse('paypal-success-response', kwargs={
-            'basket_id': basket.id}))
-    cancel_url = '%s://%s%s' % (
-        scheme, host, reverse('paypal-cancel-response', kwargs={
-            'basket_id': basket.id}))
+
+    response_view_name = 'paypal-handle-order' if buyer_pays_on_paypal() else 'paypal-success-response'
+    return_url = '%s://%s%s' % (scheme, host, reverse(response_view_name, kwargs={'basket_id': basket.id}))
+    cancel_url = '%s://%s%s' % (scheme, host, reverse('paypal-cancel-response', kwargs={'basket_id': basket.id}))
 
     # URL for updating shipping methods - we only use this if we have a set of
     # shipping methods to choose between.
     update_url = None
     if shipping_methods:
-        update_url = '%s://%s%s' % (
-            scheme, host,
-            reverse('paypal-shipping-options',
-                    kwargs={'basket_id': basket.id}))
+        update_url = '%s://%s%s' % (scheme, host, reverse('paypal-shipping-options', kwargs={'basket_id': basket.id}))
 
     # Determine whether a shipping address is required
     no_shipping = False

--- a/paypal/express/gateway.py
+++ b/paypal/express/gateway.py
@@ -29,6 +29,8 @@ API_VERSION = getattr(settings, 'PAYPAL_API_VERSION', '119')
 
 logger = logging.getLogger('paypal.express')
 
+buyer_pays_on_paypal = lambda: getattr(settings, 'PAYPAL_BUYER_PAYS_ON_PAYPAL', False)
+
 
 def _format_description(description):
     if description:
@@ -346,8 +348,15 @@ def set_txn(basket, shipping_methods, currency, return_url, cancel_url, update_u
         url = 'https://www.sandbox.paypal.com/webscr'
     else:
         url = 'https://www.paypal.com/webscr'
-    params = (('cmd', '_express-checkout'),
-              ('token', txn.token),)
+
+    params = [
+        ('cmd', '_express-checkout'),
+        ('token', txn.token)
+    ]
+
+    if buyer_pays_on_paypal():
+        params.append(('useraction', 'commit'))
+
     return '%s?%s' % (url, urlencode(params))
 
 

--- a/paypal/express/urls.py
+++ b/paypal/express/urls.py
@@ -2,17 +2,13 @@ from django.conf.urls import url
 from django.views.decorators.csrf import csrf_exempt
 
 from paypal.express import views
+from paypal.express.gateway import buyer_pays_on_paypal
 
-urlpatterns = [
+base_patterns = [
     # Views for normal flow that starts on the basket page
     url(r'^redirect/', views.RedirectView.as_view(), name='paypal-redirect'),
-    url(r'^preview/(?P<basket_id>\d+)/$',
-        views.SuccessResponseView.as_view(preview=True),
-        name='paypal-success-response'),
     url(r'^cancel/(?P<basket_id>\d+)/$', views.CancelResponseView.as_view(),
         name='paypal-cancel-response'),
-    url(r'^place-order/(?P<basket_id>\d+)/$', views.SuccessResponseView.as_view(),
-        name='paypal-place-order'),
     # Callback for getting shipping options for a specific basket
     url(r'^shipping-options/(?P<basket_id>\d+)/(?P<country_code>\w+)?',
         csrf_exempt(views.ShippingOptionsView.as_view()),
@@ -21,3 +17,24 @@ urlpatterns = [
     url(r'^payment/', views.RedirectView.as_view(as_payment_method=True),
         name='paypal-direct-payment'),
 ]
+
+
+buyer_pays_on_paypal_patterns = [
+    url(r'^handle-order/(?P<basket_id>\d+)/$',
+        views.SuccessResponseView.as_view(preview=True),
+        name='paypal-handle-order'),
+]
+
+buyer_pays_on_website_patterns = [
+    url(r'^place-order/(?P<basket_id>\d+)/$', views.SuccessResponseView.as_view(),
+        name='paypal-place-order'),
+    url(r'^preview/(?P<basket_id>\d+)/$',
+        views.SuccessResponseView.as_view(preview=True),
+        name='paypal-success-response'),
+]
+
+
+if buyer_pays_on_paypal():
+    urlpatterns = base_patterns + buyer_pays_on_paypal_patterns
+else:
+    urlpatterns = base_patterns + buyer_pays_on_website_patterns

--- a/paypal/express/views.py
+++ b/paypal/express/views.py
@@ -4,7 +4,7 @@ from decimal import Decimal as D
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.models import AnonymousUser
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.http import urlencode
@@ -19,6 +19,7 @@ from paypal.exceptions import PayPalError
 from paypal.express.exceptions import (
     EmptyBasketException, InvalidBasket, MissingShippingAddressException, MissingShippingMethodException)
 from paypal.express.facade import confirm_transaction, fetch_transaction_details, get_paypal_url
+from paypal.express.gateway import buyer_pays_on_paypal
 
 # Load views dynamically
 PaymentDetailsView = get_class('checkout.views', 'PaymentDetailsView')
@@ -171,9 +172,9 @@ class SuccessResponseView(PaymentDetailsView):
 
     def get(self, request, *args, **kwargs):
         """
-        Fetch details about the successful transaction from PayPal.  We use
-        these details to show a preview of the order with a 'submit' button to
-        place it.
+        Fetch details about the successful transaction from PayPal.
+        We use these details to show a preview of the order with a 'submit' button to place it.
+        The preview step can be skipped with `PAYPAL_BUYER_PAYS_ON_PAYPAL=True` inside settings.
         """
         try:
             self.payer_id = request.GET['PayerID']
@@ -181,30 +182,25 @@ class SuccessResponseView(PaymentDetailsView):
         except KeyError:
             # Manipulation - redirect to basket page with warning message
             logger.warning("Missing GET params on success response page")
-            messages.error(
-                self.request,
-                _("Unable to determine PayPal transaction details"))
+            messages.error(self.request, _("Unable to determine PayPal transaction details"))
             return HttpResponseRedirect(reverse('basket:summary'))
 
         try:
             self.txn = fetch_transaction_details(self.token)
         except PayPalError as e:
-            logger.warning(
-                "Unable to fetch transaction details for token %s: %s",
-                self.token, e)
+            logger.warning("Unable to fetch transaction details for token %s: %s", self.token, e)
             messages.error(self.request, self.error_message)
             return HttpResponseRedirect(reverse('basket:summary'))
 
         # Reload frozen basket which is specified in the URL
         kwargs['basket'] = self.load_frozen_basket(kwargs['basket_id'])
         if not kwargs['basket']:
-            logger.warning(
-                "Unable to load frozen basket with ID %s", kwargs['basket_id'])
-            messages.error(
-                self.request,
-                _("No basket was found that corresponds to your "
-                  "PayPal transaction"))
+            logger.warning("Unable to load frozen basket with ID %s", kwargs['basket_id'])
+            messages.error(self.request, _("No basket was found that corresponds to your PayPal transaction"))
             return HttpResponseRedirect(reverse('basket:summary'))
+
+        if buyer_pays_on_paypal():
+            return self.submit(**self.build_submission(basket=kwargs['basket']))
 
         logger.info(
             "Basket #%s - showing preview with payer ID %s and token %s",
@@ -251,6 +247,9 @@ class SuccessResponseView(PaymentDetailsView):
         We fetch the txn details again and then proceed with oscar's standard
         payment details view for placing the order.
         """
+        if buyer_pays_on_paypal():
+            return HttpResponseBadRequest()  # we don't expect any user here if we let users buy on PayPal
+
         try:
             self.payer_id = request.POST['payer_id']
             self.token = request.POST['token']

--- a/tests/unit/express/facade_tests.py
+++ b/tests/unit/express/facade_tests.py
@@ -65,7 +65,7 @@ class SuccessfulSetExpressCheckoutTests(BaseSetExpressCheckoutTests):
         self.assertTrue(self.url.has_query_param('token'))
         self.assertTrue('_express-checkout', self.url.query_param('cmd'))
 
-    def test_corrent_paypal_params(self):
+    def test_correct_paypal_params(self):
         for param in [
                 'LOCALECODE', 'HDRIMG', 'LANDINGPAGE', 'PAYFLOWCOLOR',
                 'REQCONFIRMSHIPPING', 'PAGESTYLE', 'SOLUTIONTYPE',

--- a/tests/unit/express/view_tests.py
+++ b/tests/unit/express/view_tests.py
@@ -2,7 +2,7 @@
 from decimal import Decimal as D
 from unittest.mock import Mock, patch
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.test.client import Client
 from django.urls import reverse
 from django.utils.encoding import force_text
@@ -94,7 +94,7 @@ class EdgeCaseTests(MockedPayPalTests):
                     )
 
 
-class RedirectToPayPalTests(MockedPayPalTests):
+class RedirectToPayPalBase(MockedPayPalTests):
     response_body = 'TOKEN=EC%2d8P797793UC466090M&TIMESTAMP=2012%2d04%2d16T11%3a50%3a38Z&CORRELATIONID=bdd6641577803' \
                     '&ACK=Success&VERSION=60%2e0&BUILD=2808426'  # noqa E501
 
@@ -103,11 +103,25 @@ class RedirectToPayPalTests(MockedPayPalTests):
         response = self.client.get(reverse('paypal-redirect'))
         self.url = URL.from_string(response['Location'])
 
+
+class RedirectToPayPalTests(RedirectToPayPalBase):
+
     def test_nonempty_basket_redirects_to_paypal(self):
         self.assertEqual('www.sandbox.paypal.com', self.url.host())
 
     def test_query_params_present(self):
         params = ['cmd', 'token']
+        self.assertTrue(self.url.has_query_params(params))
+
+
+@override_settings(PAYPAL_BUYER_PAYS_ON_PAYPAL=True)
+class RedirectWhenBuyerPaysOnPayPalTests(RedirectToPayPalBase):
+
+    def test_nonempty_basket_redirects_to_paypal(self):
+        self.assertEqual('www.sandbox.paypal.com', self.url.host())
+
+    def test_query_params_present(self):
+        params = ['cmd', 'token', 'useraction']
         self.assertTrue(self.url.has_query_params(params))
 
 
@@ -183,7 +197,52 @@ class PreviewOrderTests(MockedPayPalTests):
             self.assertTrue(k in self.response.context, "%s not in context" % k)
 
 
-class SubmitOrderTests(MockedPayPalTests):
+class SubmitOrderBase(MockedPayPalTests):
+    get_response = ''
+    do_response = ''
+
+    def patch_http_post(self, post):
+        get_response = self.get_response
+        do_response = self.do_response
+
+        def side_effect(url, payload, **kwargs):
+            if 'GetExpressCheckoutDetails' in payload:
+                return self.get_mock_response(get_response)
+            elif 'DoExpressCheckoutPayment' in payload:
+                return self.get_mock_response(do_response)
+        post.side_effect = side_effect
+
+
+class SubmitOrderTests(SubmitOrderBase):
+    get_response = 'TOKEN=EC%2d6WY34243AN3588740&CHECKOUTSTATUS=PaymentActionCompleted&' \
+                   'TIMESTAMP=2012%2d04%2d19T10%3a07%3a46Z&CORRELATIONID=7e9c5efbda3c0&ACK=Success&' \
+                   'VERSION=88%2e0&BUILD=2808426&EMAIL=david%2e_1332854868_per%40gmail%2ecom&' \
+                   'PAYERID=7ZTRBDFYYA47W&PAYERSTATUS=verified&FIRSTNAME=David&LASTNAME=Winterbottom&COUNTRYCODE=GB&' \
+                   'SHIPTONAME=David%20Winterbottom&SHIPTOSTREET=1%20Main%20Terrace&SHIPTOSTREET2=line2&' \
+                   'SHIPTOCITY=Wolverhampton&SHIPTOSTATE=West%20Midlands&SHIPTOZIP=W12%204LQ&SHIPTOCOUNTRYCODE=GB&' \
+                   'SHIPTOCOUNTRYNAME=United%20Kingdom&ADDRESSSTATUS=Confirmed&CURRENCYCODE=GBP&' \
+                   'AMT=33%2e98&SHIPPINGAMT=0%2e00&HANDLINGAMT=0%2e00&TAXAMT=0%2e00&INSURANCEAMT=0%2e00&' \
+                   'SHIPDISCAMT=0%2e00&PAYMENTREQUEST_0_CURRENCYCODE=GBP&PAYMENTREQUEST_0_AMT=33%2e98&' \
+                   'PAYMENTREQUEST_0_SHIPPINGAMT=0%2e00&PAYMENTREQUEST_0_HANDLINGAMT=0%2e00&' \
+                   'PAYMENTREQUEST_0_TAXAMT=0%2e00&PAYMENTREQUEST_0_INSURANCEAMT=0%2e00&' \
+                   'PAYMENTREQUEST_0_SHIPDISCAMT=0%2e00&PAYMENTREQUEST_0_TRANSACTIONID=51963679RW630412N&' \
+                   'PAYMENTREQUEST_0_INSURANCEOPTIONOFFERED=false&PAYMENTREQUEST_0_SHIPTONAME=David%20Winterbottom&' \
+                   'PAYMENTREQUEST_0_SHIPTOSTREET=1%20Main%20Terrace&PAYMENTREQUEST_0_SHIPTOSTREET2=line2&' \
+                   'PAYMENTREQUEST_0_SHIPTOCITY=Wolverhampton&PAYMENTREQUEST_0_SHIPTOSTATE=West%20Midlands&' \
+                   'PAYMENTREQUEST_0_SHIPTOZIP=W12%204LQ&PAYMENTREQUEST_0_SHIPTOCOUNTRYCODE=GB&' \
+                   'PAYMENTREQUEST_0_SHIPTOCOUNTRYNAME=United%20Kingdom&' \
+                   'PAYMENTREQUESTINFO_0_TRANSACTIONID=51963679RW630412N&PAYMENTREQUESTINFO_0_ERRORCODE=0'
+    do_response = 'TOKEN=EC%2d6WY34243AN3588740&SUCCESSPAGEREDIRECTREQUESTED=false&' \
+                  'TIMESTAMP=2012%2d04%2d19T10%3a07%3a47Z&CORRELATIONID=3db1d5276ddfd&ACK=Success&VERSION=88%2e0&' \
+                  'BUILD=2808426&INSURANCEOPTIONSELECTED=false&SHIPPINGOPTIONISDEFAULT=false&' \
+                  'PAYMENTINFO_0_TRANSACTIONID=51963679RW630412N&PAYMENTINFO_0_TRANSACTIONTYPE=expresscheckout&' \
+                  'PAYMENTINFO_0_PAYMENTTYPE=instant&PAYMENTINFO_0_ORDERTIME=2012%2d04%2d19T09%3a42%3a50Z&' \
+                  'PAYMENTINFO_0_AMT=33%2e98&PAYMENTINFO_0_FEEAMT=1%2e36&PAYMENTINFO_0_TAXAMT=0%2e00&' \
+                  'PAYMENTINFO_0_CURRENCYCODE=GBP&PAYMENTINFO_0_PAYMENTSTATUS=Pending&' \
+                  'PAYMENTINFO_0_PENDINGREASON=paymentreview&PAYMENTINFO_0_REASONCODE=None&' \
+                  'PAYMENTINFO_0_PROTECTIONELIGIBILITY=Ineligible&PAYMENTINFO_0_PROTECTIONELIGIBILITYTYPE=None&' \
+                  'PAYMENTINFO_0_SECUREMERCHANTACCOUNTID=YYH7BB4UHPKC4&PAYMENTINFO_0_ERRORCODE=0&' \
+                  'PAYMENTINFO_0_ACK=Success'
 
     def perform_action(self):
         self.add_product_to_basket(price=D('6.99'))
@@ -198,47 +257,6 @@ class SubmitOrderTests(MockedPayPalTests):
                   'token': 'EC-8P797793UC466090M'})
         self.order = Order.objects.all()[0]
 
-    def patch_http_post(self, post):
-        get_response = 'TOKEN=EC%2d6WY34243AN3588740&CHECKOUTSTATUS=PaymentActionCompleted' \
-                       '&TIMESTAMP=2012%2d04%2d19T10%3a07%3a46Z&CORRELATIONID=7e9c5efbda3c0' \
-                       '&ACK=Success&VERSION=88%2e0&BUILD=2808426&EMAIL=david%2e_1332854868_per%40gmail%2ecom' \
-                       '&PAYERID=7ZTRBDFYYA47W&PAYERSTATUS=verified&FIRSTNAME=David&LASTNAME=Winterbottom' \
-                       '&COUNTRYCODE=GB&SHIPTONAME=David%20Winterbottom&SHIPTOSTREET=1%20Main%20Terrace' \
-                       '&SHIPTOSTREET2=line2&SHIPTOCITY=Wolverhampton&SHIPTOSTATE=West%20Midlands' \
-                       '&SHIPTOZIP=W12%204LQ&SHIPTOCOUNTRYCODE=GB&SHIPTOCOUNTRYNAME=United%20Kingdom' \
-                       '&ADDRESSSTATUS=Confirmed&CURRENCYCODE=GBP&AMT=33%2e98&SHIPPINGAMT=0%2e00' \
-                       '&HANDLINGAMT=0%2e00&TAXAMT=0%2e00&INSURANCEAMT=0%2e00&SHIPDISCAMT=0%2e00' \
-                       '&PAYMENTREQUEST_0_CURRENCYCODE=GBP&PAYMENTREQUEST_0_AMT=33%2e98' \
-                       '&PAYMENTREQUEST_0_SHIPPINGAMT=0%2e00&PAYMENTREQUEST_0_HANDLINGAMT=0%2e00' \
-                       '&PAYMENTREQUEST_0_TAXAMT=0%2e00&PAYMENTREQUEST_0_INSURANCEAMT=0%2e00' \
-                       '&PAYMENTREQUEST_0_SHIPDISCAMT=0%2e00&PAYMENTREQUEST_0_TRANSACTIONID=51963679RW630412N' \
-                       '&PAYMENTREQUEST_0_INSURANCEOPTIONOFFERED=false' \
-                       '&PAYMENTREQUEST_0_SHIPTONAME=David%20Winterbottom' \
-                       '&PAYMENTREQUEST_0_SHIPTOSTREET=1%20Main%20Terrace&PAYMENTREQUEST_0_SHIPTOSTREET2=line2' \
-                       '&PAYMENTREQUEST_0_SHIPTOCITY=Wolverhampton&PAYMENTREQUEST_0_SHIPTOSTATE=West%20Midlands' \
-                       '&PAYMENTREQUEST_0_SHIPTOZIP=W12%204LQ&PAYMENTREQUEST_0_SHIPTOCOUNTRYCODE=GB' \
-                       '&PAYMENTREQUEST_0_SHIPTOCOUNTRYNAME=United%20Kingdom' \
-                       '&PAYMENTREQUESTINFO_0_TRANSACTIONID=51963679RW630412N' \
-                       '&PAYMENTREQUESTINFO_0_ERRORCODE=0'   # noqa E501
-        do_response = 'TOKEN=EC%2d6WY34243AN3588740&SUCCESSPAGEREDIRECTREQUESTED=false' \
-                      '&TIMESTAMP=2012%2d04%2d19T10%3a07%3a47Z&CORRELATIONID=3db1d5276ddfd&ACK=Success' \
-                      '&VERSION=88%2e0&BUILD=2808426&INSURANCEOPTIONSELECTED=false&SHIPPINGOPTIONISDEFAULT=false' \
-                      '&PAYMENTINFO_0_TRANSACTIONID=51963679RW630412N&PAYMENTINFO_0_TRANSACTIONTYPE=expresscheckout' \
-                      '&PAYMENTINFO_0_PAYMENTTYPE=instant&PAYMENTINFO_0_ORDERTIME=2012%2d04%2d19T09%3a42%3a50Z' \
-                      '&PAYMENTINFO_0_AMT=33%2e98&PAYMENTINFO_0_FEEAMT=1%2e36&PAYMENTINFO_0_TAXAMT=0%2e00' \
-                      '&PAYMENTINFO_0_CURRENCYCODE=GBP&PAYMENTINFO_0_PAYMENTSTATUS=Pending' \
-                      '&PAYMENTINFO_0_PENDINGREASON=paymentreview&PAYMENTINFO_0_REASONCODE=None' \
-                      '&PAYMENTINFO_0_PROTECTIONELIGIBILITY=Ineligible&PAYMENTINFO_0_PROTECTIONELIGIBILITYTYPE=None' \
-                      '&PAYMENTINFO_0_SECUREMERCHANTACCOUNTID=YYH7BB4UHPKC4&PAYMENTINFO_0_ERRORCODE=0' \
-                      '&PAYMENTINFO_0_ACK=Success'     # noqa E501
-
-        def side_effect(url, payload, **kwargs):
-            if 'GetExpressCheckoutDetails' in payload:
-                return self.get_mock_response(get_response)
-            elif 'DoExpressCheckoutPayment' in payload:
-                return self.get_mock_response(do_response)
-        post.side_effect = side_effect
-
     def test_order_total(self):
         self.assertEqual(D('6.99'), self.order.total_incl_tax)
 
@@ -248,6 +266,75 @@ class SubmitOrderTests(MockedPayPalTests):
 
     def test_shipping_address_includes_line2(self):
         self.assertEqual('line2', self.order.shipping_address.line2)
+
+
+@override_settings(PAYPAL_BUYER_PAYS_ON_PAYPAL=True)
+class BuyerPaysOnPaypalResponseTests(SubmitOrderBase):
+    get_response = 'TOKEN=EC%2d7F151994RW7618524&BILLINGAGREEMENTACCEPTEDSTATUS=0&' \
+                   'CHECKOUTSTATUS=PaymentActionNotInitiated&' \
+                   'TIMESTAMP=2014%2d12%2d14T10%3a49%3a10Z&CORRELATIONID=5ef454cceaf17&ACK=Success&VERSION=119&' \
+                   'BUILD=14107150&EMAIL=info%2dbuyer%40test%2ecom&PAYERID=Y8K3PSJYN24D4&PAYERSTATUS=verified&' \
+                   'FIRSTNAME=Test&LASTNAME=Buyer&COUNTRYCODE=IT&SHIPTONAME=Test%20Buyer&' \
+                   'SHIPTOSTREET=street%20Test%2c%201&SHIPTOSTREET2=line2&SHIPTOCITY=London&SHIPTOSTATE=London&' \
+                   'SHIPTOZIP=SW74TU&SHIPTOCOUNTRYCODE=GB&SHIPTOCOUNTRYNAME=United%20Kingdom&' \
+                   'ADDRESSSTATUS=Confirmed&CURRENCYCODE=EUR&AMT=23%2e99&ITEMAMT=23%2e99&SHIPPINGAMT=0%2e00&' \
+                   'HANDLINGAMT=0%2e00&TAXAMT=0%2e00&INSURANCEAMT=0%2e00&SHIPDISCAMT=0%2e00&' \
+                   'L_NAME0=Hacking%20Exposed%20Wireless&L_NUMBER0=9780072262582&L_QTY0=1&' \
+                   'L_TAXAMT0=0%2e00&L_AMT0=23%2e99&L_DESC0=This%20is%20an%20invaluable%20resource%20for%20any%' \
+                   '20IT%20professional%20who%20works%' \
+                   '20with%20%2e%2e%2e&L_ITEMWEIGHTVALUE0=%20%20%200%2e00000&L_ITEMLENGTHVALUE0=%20%20%200%2e00000&' \
+                   'L_ITEMWIDTHVALUE0=%20%20%200%2e00000&L_ITEMHEIGHTVALUE0=%20%20%200%2e00000&' \
+                   'PAYMENTREQUEST_0_CURRENCYCODE=EUR&PAYMENTREQUEST_0_AMT=23%2e99&PAYMENTREQUEST_0_ITEMAMT=23%2e99&' \
+                   'PAYMENTREQUEST_0_SHIPPINGAMT=0%2e00&PAYMENTREQUEST_0_HANDLINGAMT=0%2e00&' \
+                   'PAYMENTREQUEST_0_TAXAMT=0%2e00&PAYMENTREQUEST_0_INSURANCEAMT=0%2e00&' \
+                   'PAYMENTREQUEST_0_SHIPDISCAMT=0%2e00&PAYMENTREQUEST_0_INSURANCEOPTIONOFFERED=false&' \
+                   'PAYMENTREQUEST_0_SHIPTONAME=Test%20Buyer&PAYMENTREQUEST_0_SHIPTOSTREET=street%20Test%2c%201&' \
+                   'PAYMENTREQUEST_0_SHIPTOSTREET2=line2&PAYMENTREQUEST_0_SHIPTOCITY=London&' \
+                   'PAYMENTREQUEST_0_SHIPTOSTATE=London&PAYMENTREQUEST_0_SHIPTOZIP=SW74TU&' \
+                   'PAYMENTREQUEST_0_SHIPTOCOUNTRYCODE=GB&PAYMENTREQUEST_0_SHIPTOCOUNTRYNAME=United%20Kingdom&' \
+                   'PAYMENTREQUEST_0_ADDRESSSTATUS=Confirmed&PAYMENTREQUEST_0_ADDRESSNORMALIZATIONSTATUS=None&' \
+                   'L_PAYMENTREQUEST_0_NAME0=Hacking%20Exposed%20Wireless&L_PAYMENTREQUEST_0_NUMBER0=9780072262582&' \
+                   'L_PAYMENTREQUEST_0_QTY0=1&L_PAYMENTREQUEST_0_TAXAMT0=0%2e00&L_PAYMENTREQUEST_0_AMT0=23%2e99&' \
+                   'L_PAYMENTREQUEST_0_DESC0=This%20is%20an%20invaluable%20resource%20for%20any%20IT%20professional' \
+                   '%20who%20works%20with%20%2e%2e%2e&L_PAYMENTREQUEST_0_ITEMWEIGHTVALUE0=%20%20%200%2e00000&' \
+                   'L_PAYMENTREQUEST_0_ITEMLENGTHVALUE0=%20%20%200%2e00000&' \
+                   'L_PAYMENTREQUEST_0_ITEMWIDTHVALUE0=%20%20%200%2e00000&' \
+                   'L_PAYMENTREQUEST_0_ITEMHEIGHTVALUE0=%20%20%200%2e00000&PAYMENTREQUESTINFO_0_ERRORCODE=0'
+    do_response = 'TOKEN=EC%2d7F151994RW7618524&SUCCESSPAGEREDIRECTREQUESTED=false&' \
+                  'TIMESTAMP=2014%2d12%2d14T10%3a49%3a42Z&CORRELATIONID=30e7eb7f96acc&ACK=Success&VERSION=119&' \
+                  'BUILD=14107150&INSURANCEOPTIONSELECTED=false&SHIPPINGOPTIONISDEFAULT=false&' \
+                  'PAYMENTINFO_0_TRANSACTIONID=7TR35978HS6402734&PAYMENTINFO_0_TRANSACTIONTYPE=expresscheckout&' \
+                  'PAYMENTINFO_0_PAYMENTTYPE=instant&PAYMENTINFO_0_ORDERTIME=2014%2d12%2d14T10%3a49%3a42Z&' \
+                  'PAYMENTINFO_0_AMT=23%2e99&PAYMENTINFO_0_TAXAMT=0%2e00&PAYMENTINFO_0_CURRENCYCODE=EUR&' \
+                  'PAYMENTINFO_0_PAYMENTSTATUS=Pending&PAYMENTINFO_0_PENDINGREASON=multicurrency&' \
+                  'PAYMENTINFO_0_REASONCODE=None&PAYMENTINFO_0_PROTECTIONELIGIBILITY=Eligible&' \
+                  'PAYMENTINFO_0_PROTECTIONELIGIBILITYTYPE=ItemNotReceivedEligible%2cUnauthorizedPaymentEligible&' \
+                  'PAYMENTINFO_0_SECUREMERCHANTACCOUNTID=N7DUXYBV52FQ4&PAYMENTINFO_0_ERRORCODE=0&' \
+                  'PAYMENTINFO_0_ACK=Success'
+
+    def perform_action(self):
+        self.add_product_to_basket(price=D('23.99'))
+        basket = Basket.objects.first()
+        basket.freeze()
+
+        self.url = reverse('paypal-handle-order', kwargs={'basket_id': basket.id})
+        url = URL().path(self.url) \
+            .query_param('PayerID', 'Y8K3PSJYN24D4') \
+            .query_param('token', 'EC-7F151994RW7618524')
+        self.response = self.client.get(str(url), follow=True)
+        self.order = Order.objects.first()
+
+    def test_order_total(self):
+        self.assertEqual(D('23.99'), self.order.total_incl_tax)
+
+    def test_order_email_address(self):
+        self.assertEqual('info-buyer@test.com', self.order.guest_email)
+
+    def test_order_includes_shipping(self):
+        self.assertEqual('line2', self.order.shipping_address.line2)
+
+    def test_post_should_is_a_bad_request(self):
+        self.assertEqual(self.client.post(self.url, {}).status_code, 400)
 
 
 class SubmitOrderErrorsTests(MockedPayPalTests):

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -2,10 +2,14 @@ from django.apps import apps
 from django.conf.urls import include, url
 from django.conf.urls.i18n import i18n_patterns
 
+from paypal.express.urls import base_patterns, buyer_pays_on_paypal_patterns, buyer_pays_on_website_patterns
+
 urlpatterns = [
     url(r'^i18n/', include('django.conf.urls.i18n')),
 ]
 urlpatterns += i18n_patterns(
-    url(r'^checkout/paypal/', include('paypal.express.urls')),
+    url(r'^checkout/paypal/', include(base_patterns)),
+    url(r'^checkout/paypal/option-paypal/', include(buyer_pays_on_paypal_patterns)),
+    url(r'^checkout/paypal/option-website/', include(buyer_pays_on_website_patterns)),
     url(r'^', include(apps.get_app_config("oscar").urls[0])),
 )


### PR DESCRIPTION
Based of https://github.com/django-oscar/django-oscar-paypal/pull/46 and @itbabu's work.

Introduces a setting to enable direct payments from the Paypal page. Prevents the preview step.