### PR TITLE
docs: Fix simple typo, trnslate -> translate

### DIFF
--- a/paypal/payflow/codes.py
+++ b/paypal/payflow/codes.py
@@ -1,4 +1,4 @@
-# Make strings collectable with gettext tools, but don't trnslate them here:
+# Make strings collectable with gettext tools, but don't translate them here:
 _ = lambda x: x
 
 # Transaction types (TRXTYPE)...


### PR DESCRIPTION
There is a small typo in paypal/payflow/codes.py.

Should read `translate` rather than `trnslate`.

