### PR TITLE
Fix redirect URL name for paypal-payflow-detail in dashboard.

### DIFF
--- a/paypal/payflow/dashboard/views.py
+++ b/paypal/payflow/dashboard/views.py
@@ -1,7 +1,7 @@
 from django import http
 from django.conf import settings
 from django.contrib import messages
-from django.urls import reverse
+from django.shortcuts import redirect
 from django.utils.translation import gettext as _
 from django.views import generic
 
@@ -29,8 +29,7 @@ class TransactionDetailView(generic.DetailView):
         orig_txn = self.get_object()
         if not getattr(settings, 'PAYPAL_PAYFLOW_DASHBOARD_FORMS', False):
             messages.error(self.request, _("Dashboard actions not permitted"))
-            return http.HttpResponseRedirect(
-                reverse('paypal-payflow-detail', kwargs={'pk': orig_txn.id}))
+            return redirect('payflow_dashboard:paypal-payflow-detail', pk=orig_txn.id)
         dispatch_map = {
             'credit': self.credit,
             'void': self.void,
@@ -47,34 +46,28 @@ class TransactionDetailView(generic.DetailView):
         except Exception as e:
             messages.error(
                 self.request, _("Unable to settle transaction - %s") % e)
-            return http.HttpResponseRedirect(
-                reverse('paypal-payflow-detail', kwargs={'pk': orig_txn.id}))
+            return redirect('payflow_dashboard:paypal-payflow-detail', pk=orig_txn.id)
         else:
             messages.success(
                 self.request, _("Transaction %s settled") % orig_txn.pnref)
-            return http.HttpResponseRedirect(reverse('paypal-payflow-detail',
-                                                     kwargs={'pk': txn.id}))
+            return redirect('payflow_dashboard:paypal-payflow-detail', pk=txn.id)
 
     def credit(self, orig_txn):
         try:
             txn = facade.credit(orig_txn.comment1)
         except Exception as e:
             messages.error(self.request, _("Unable to credit transaction - %s") % e)
-            return http.HttpResponseRedirect(reverse('paypal-payflow-detail',
-                                                     kwargs={'pk': orig_txn.id}))
+            return redirect('payflow_dashboard:paypal-payflow-detail', pk=orig_txn.id)
         else:
             messages.success(self.request, _("Transaction %s credited") % orig_txn.pnref)
-            return http.HttpResponseRedirect(reverse('paypal-payflow-detail',
-                                                     kwargs={'pk': txn.id}))
+            return redirect('payflow_dashboard:paypal-payflow-detail', pk=txn.id)
 
     def void(self, orig_txn):
         try:
             txn = facade.void(orig_txn.comment1, orig_txn.pnref)
         except Exception as e:
             messages.error(self.request, _("Unable to void transaction - %s") % e)
-            return http.HttpResponseRedirect(reverse('paypal-payflow-detail',
-                                                     kwargs={'pk': orig_txn.id}))
+            return redirect('payflow_dashboard:paypal-payflow-detail', pk=orig_txn.id)
         else:
             messages.success(self.request, _("Transaction %s voided") % orig_txn.pnref)
-            return http.HttpResponseRedirect(reverse('paypal-payflow-detail',
-                                                     kwargs={'pk': txn.id}))
+            return redirect('payflow_dashboard:paypal-payflow-detail', pk=txn.id)

--- a/sandbox/apps/checkout/views.py
+++ b/sandbox/apps/checkout/views.py
@@ -1,6 +1,5 @@
 from django.contrib import messages
-from django.http import HttpResponseRedirect
-from django.urls import reverse
+from django.shortcuts import redirect
 from oscar.apps.checkout import views
 from oscar.apps.payment import forms, models
 
@@ -61,7 +60,7 @@ class PaymentDetailsView(views.PaymentDetailsView):
         if not all([bankcard_form.is_valid(),
                     billing_address_form.is_valid()]):
             messages.error(request, "Invalid submission")
-            return HttpResponseRedirect(reverse('checkout:payment-details'))
+            return redirect('checkout:payment-details')
 
         # Attempt to submit the order, passing the bankcard object so that it
         # gets passed back to the 'handle_payment' method below.


### PR DESCRIPTION
Also use Django's redirect shortcut for redirects for simplicity.

Fixes #244.