### PR TITLE
-fixed max_length 'status' field

### DIFF
--- a/paypal/express_checkout/models.py
+++ b/paypal/express_checkout/models.py
@@ -20,7 +20,7 @@ class ExpressCheckoutTransaction(models.Model):
     currency = models.CharField(max_length=8, null=True, blank=True)
 
     CREATED, SAVED, APPROVED, VOIDED, COMPLETED = 'CREATED', 'SAVED', 'APPROVED', 'VOIDED', 'COMPLETED'
-    status = models.CharField(max_length=8)
+    status = models.CharField(max_length=9)
 
     AUTHORIZE, CAPTURE = 'AUTHORIZE', 'CAPTURE'
     intent = models.CharField(max_length=9)


### PR DESCRIPTION
-row 'status' in express_checkout models should be 9 character to contain the 'COMPLETED' status