### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/express.rst
+++ b/docs/express.rst
@@ -102,7 +102,7 @@ Express.
 Settings
 --------
 
-There's a smorgasboard of options that can be used, as there's many ways to
+There's a smorgasbord of options that can be used, as there's many ways to
 customised the Express Checkout experience.  Most of these are handled by simple
 settings.
 

--- a/docs/payflow.rst
+++ b/docs/payflow.rst
@@ -91,7 +91,7 @@ Optional settings:
 ``PAYPAL_PAYFLOW_CURRENCY``
     The 3 character currency code to use for transactions.  Defaults to 'USD'.
 ``PAYPAL_PAYFLOW_USER``
-    The ID of the user authorised to process transations.  If you only have one
+    The ID of the user authorised to process transactions.  If you only have one
     user on the account, then this is the same as the VENDOR_ID and there is no
     need to specify it.
 ``PAYPAL_PAYFLOW_PARTNER``

--- a/paypal/express/facade.py
+++ b/paypal/express/facade.py
@@ -1,5 +1,5 @@
 """
-Responsible for briding between Oscar and the PayPal gateway
+Responsible for bridging between Oscar and the PayPal gateway
 """
 from django.conf import settings
 from django.contrib.sites.models import Site

--- a/paypal/payflow/facade.py
+++ b/paypal/payflow/facade.py
@@ -161,7 +161,7 @@ def credit(order_number, pnref=None, amt=None):
     :pnref: The PNREF of the authorization transaction to use.  If not
             specified, the order number is used to retrieve the appropriate transaction.
     :amt: A custom amount to capture.  If not specified, the entire transaction
-          is refuneded.
+          is refunded.
     """
     if pnref is None:
         # No PNREF specified, look-up the auth/sale transaction for this order number

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -328,7 +328,7 @@ PAYPAL_PAYFLOW_DASHBOARD_FORMS = True
 PAYPAL_CLIENT_ID = ''
 PAYPAL_CLIENT_SECRET = ''
 
-# Put your own sandbox settings into an integration.py modulde (that is ignored
+# Put your own sandbox settings into an integration.py module (that is ignored
 # by git).
 try:
     from integration import *  # noqa


### PR DESCRIPTION
There are small typos in:
- docs/express.rst
- docs/payflow.rst
- paypal/express/facade.py
- paypal/payflow/facade.py
- sandbox/settings.py

Fixes:
- Should read `transactions` rather than `transations`.
- Should read `smorgasbord` rather than `smorgasboard`.
- Should read `refunded` rather than `refuneded`.
- Should read `module` rather than `modulde`.
- Should read `bridging` rather than `briding`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md